### PR TITLE
test(core): skip grid-dashboard demo case when Arial Unicode is absent

### DIFF
--- a/packages/core/tests/templates-demo.regression.test.ts
+++ b/packages/core/tests/templates-demo.regression.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { renderDocumentWithLayout } from '../src/index';
 // Registers `toMatchPDFSnapshot` on Vitest's `expect`.
@@ -10,8 +11,14 @@ import Report from '../../../templates/report';
 import ShippingLabel from '../../../templates/shipping-label';
 import ChartsShowcase from '../../../templates/charts-showcase';
 import FeatureShowcase from '../../../templates/feature-showcase';
-import GridDashboard from '../../../templates/grid-dashboard';
 import Typography from '../../../templates/typography';
+
+// `grid-dashboard` registers a macOS system font (Arial Unicode) at module
+// scope, so it is imported lazily in its own guarded test below — importing it
+// here would `Font.register` that absolute path globally and, since the
+// serializer folds every registered font into each document's `fonts`, make
+// *every* case in this file fail to resolve it on machines without that font
+// (all of CI, which is Linux). See ARIAL_UNICODE_PATH below.
 
 import invoiceData from '../../../templates/invoice-data.json';
 import receiptData from '../../../templates/receipt-data.json';
@@ -53,12 +60,19 @@ const CASES: Record<string, [(data: any) => any, unknown]> = {
   // Gallery templates (docs template-gallery). charts-showcase and
   // feature-showcase are self-contained (data ignored / none exists);
   // all four render deterministically on undefined data as of the
-  // 2026-09 contract fixes.
+  // 2026-09 contract fixes. `grid-dashboard` is covered separately below
+  // because it depends on a macOS-only system font.
   'charts-showcase': [ChartsShowcase, chartsShowcaseData],
   'feature-showcase': [FeatureShowcase, undefined],
-  'grid-dashboard': [GridDashboard, gridDashboardData],
   typography: [Typography, typographyData],
 };
+
+// grid-dashboard registers this font at module scope. It ships with macOS but
+// is absent on Linux CI (and on Macs where it isn't installed), so the case is
+// skipped rather than failed when the file isn't there — matching the engine
+// integration suite's handling of the same font.
+const ARIAL_UNICODE_PATH = '/System/Library/Fonts/Supplemental/Arial Unicode.ttf';
+const hasArialUnicode = existsSync(ARIAL_UNICODE_PATH);
 
 describe('demo template regressions (/templates)', () => {
   it.each(Object.entries(CASES))(
@@ -69,6 +83,18 @@ describe('demo template regressions (/templates)', () => {
       // Pass LayoutInfo directly — the authoritative FormePDF fast path
       // (no PDF parsing, every node at confidence 1.0).
       await expect(layout).toMatchPDFSnapshot({ snapshotName: `demo-${name}` });
+    },
+  );
+
+  it.skipIf(!hasArialUnicode)(
+    'grid-dashboard layout matches the committed structural baseline',
+    async () => {
+      // Lazy import so the module-scope Font.register only fires when the font
+      // is present — keeping the global registry (and thus the other cases
+      // above) clean on machines without it.
+      const { default: GridDashboard } = await import('../../../templates/grid-dashboard');
+      const { layout } = await renderDocumentWithLayout(GridDashboard(gridDashboardData));
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: 'demo-grid-dashboard' });
     },
   );
 });


### PR DESCRIPTION
## Problem

`main`'s CI is red on the **Test Templates (regression)** step — all nine demo cases fail with:

```
ENOENT: no such file or directory, open '/System/Library/Fonts/Supplemental/Arial Unicode.ttf'
```

The `grid-dashboard` demo template registers that absolute macOS path via `Font.register` at **module scope**. Because the serializer folds every globally-registered font into each document's `fonts`, statically importing the template poisoned *every* case in the file — they all try to read a font that doesn't exist on Linux CI (or on Macs without Arial Unicode installed).

CLAUDE.md already documents the rule this violated: *"Integration tests that depend on macOS system fonts (e.g., Arial Unicode) must gracefully skip when the font file is absent. CI runs on Linux and doesn't have `/System/Library/Fonts/`."* The engine integration suite already guards the same font; this demo suite didn't.

## Fix

- Drop the static `import GridDashboard` and remove it from the shared `CASES`.
- Cover it in its own `it.skipIf(!hasArialUnicode)` case that **lazily** imports the template, so the module-scope `Font.register` only fires when the font is actually present — keeping the global registry (and the other seven cases) clean on machines without it.

No template or baseline changes; the grid-dashboard snapshot is unchanged and still verified wherever the font exists.

## Verification

`npm run test:templates` in `packages/core` on a Mac with the font present: **16 passed** (grid-dashboard runs and matches its baseline). On Linux CI the grid-dashboard case will skip and the other cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)