### PR TITLE
Page-number placeholders no longer switch fonts (fixes custom-font footers + PDF/A)

### DIFF
--- a/engine/src/font/fallback.rs
+++ b/engine/src/font/fallback.rs
@@ -37,13 +37,18 @@ pub fn segment_by_font(
         return vec![];
     }
 
-    // Fast path: single font family — check if all chars are covered
+    // Fast path: single font family — check if all chars are covered.
+    // Page-number sentinels are exempt like whitespace: they're replaced
+    // by digits at write time, so no font can (or needs to) cover them.
     if !families.contains(',') {
         let family = families.trim().trim_matches('"').trim_matches('\'');
         let font = registry.resolve(family, weight, italic);
-        let all_covered = chars
-            .iter()
-            .all(|&ch| ch.is_whitespace() || font.has_char(ch));
+        let all_covered = chars.iter().all(|&ch| {
+            ch.is_whitespace()
+                || ch == crate::layout::PAGE_NUMBER_SENTINEL
+                || ch == crate::layout::TOTAL_PAGES_SENTINEL
+                || font.has_char(ch)
+        });
         if all_covered {
             return vec![FontRun {
                 start: 0,

--- a/engine/src/font/mod.rs
+++ b/engine/src/font/mod.rs
@@ -311,6 +311,40 @@ impl FontRegistry {
     ) -> (&FontData, String) {
         let snapped_weight = if weight >= 600 { 700 } else { 400 };
 
+        // Page-number sentinels (U+0002/U+0003) are pseudo-characters
+        // replaced by DIGITS at write time — no real font has a glyph for
+        // them, so a coverage walk would always shunt them into the final
+        // Helvetica fallback, splitting the surrounding text's font (and
+        // breaking PDF/A when that font is a registered custom one). They
+        // are font-neutral: take the first REGISTERED family in the chain,
+        // ignoring coverage. Known boundary: a registered font genuinely
+        // lacking digit glyphs still renders .notdef page numbers, like
+        // any other missing glyph.
+        if ch == crate::layout::PAGE_NUMBER_SENTINEL || ch == crate::layout::TOTAL_PAGES_SENTINEL {
+            for family in families.split(',') {
+                let family = family.trim().trim_matches('"').trim_matches('\'');
+                if family.is_empty() {
+                    continue;
+                }
+                for w in [
+                    weight,
+                    snapped_weight,
+                    if snapped_weight == 700 { 400 } else { 700 },
+                ] {
+                    let key = FontKey {
+                        family: family.to_string(),
+                        weight: w,
+                        italic,
+                    };
+                    if let Some(font) = self.fonts.get(&key) {
+                        return (font, family.to_string());
+                    }
+                }
+            }
+            // No family in the chain is registered: same terminal
+            // fallback as the coverage walk below.
+        }
+
         for family in families.split(',') {
             let family = family.trim().trim_matches('"').trim_matches('\'');
             if family.is_empty() {

--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -2763,6 +2763,15 @@ impl PdfWriter {
                             glyph_to_char: HashMap::new(),
                         });
                         usage.chars.insert(glyph.char_value);
+                        // A page-number sentinel becomes digits at write
+                        // time — subset all ten for this font, or the
+                        // substituted numbers would render as .notdef
+                        // (char_to_gid would have no digit entries).
+                        if glyph.char_value == PAGE_NUMBER_SENTINEL
+                            || glyph.char_value == TOTAL_PAGES_SENTINEL
+                        {
+                            usage.chars.extend('0'..='9');
+                        }
                         usage.glyph_ids.insert(glyph.glyph_id);
                         // For ligatures, use the first char of the cluster
                         usage

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -152,7 +152,10 @@ fn assert_valid_pdf(bytes: &[u8]) {
 fn decompress_pdf_streams(pdf: &[u8]) -> String {
     use miniz_oxide::inflate::decompress_to_vec_zlib;
     let mut result = String::new();
-    let needle_start = b"stream\n";
+    // Leading newline so the needle can't match the tail of "endstream\n":
+    // without it, the first binary (font-file) stream desyncs the scan and
+    // every stream after it is silently skipped.
+    let needle_start = b"\nstream\n";
     let needle_end = b"\nendstream";
     let mut pos = 0;
     while pos + needle_start.len() < pdf.len() {
@@ -12103,5 +12106,159 @@ fn test_parity_translation_excludes_page_anchored_watermarks() {
     assert!(
         (text_x_p2 - 30.0).abs() < 0.5,
         "page 2 (left) flow x: {text_x_p2}"
+    );
+}
+
+// ─── Page-number sentinels must not change the font ───────────────────
+//
+// `{{pageNumber}}`/`{{totalPages}}` become sentinel chars (U+0002/U+0003)
+// at layout time and real digits at write time. No font covers a control
+// char, so coverage-based fallback used to shunt the sentinel into
+// Helvetica — splitting one footer line across two typefaces, emitting a
+// non-embedded base-14 font, and hard-failing PDF/A. The fix has two
+// halves that must hold together: segmentation treats sentinels as
+// font-neutral, and the subset includes digits 0-9 for any font that
+// carried a sentinel (fixing only the first turns visible-wrong-font
+// into invisible .notdef).
+
+/// The committed builtin font bytes registered under a CUSTOM family —
+/// a real TTF with no filesystem/system-font dependency.
+fn sentinel_test_doc(extra_document_fields: &str) -> String {
+    let font_b64 = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        include_bytes!("../fonts/NotoSans-Regular.ttf"),
+    );
+    format!(
+        r#"{{
+            "children": [
+                {{ "kind": {{ "type": "Fixed", "position": "Footer" }}, "style": {{}}, "children": [
+                    {{ "kind": {{ "type": "Text", "content": "Page {{{{pageNumber}}}} of {{{{totalPages}}}}" }},
+                       "style": {{ "fontFamily": "TestSans", "fontSize": 9 }}, "children": [] }}
+                ]}},
+                {{ "kind": {{ "type": "Text", "content": "body" }}, "style": {{ "marginBottom": 900 }}, "children": [] }},
+                {{ "kind": {{ "type": "Text", "content": "second page body" }}, "style": {{}}, "children": [] }}
+            ],
+            "metadata": {{ "lang": "de-DE" }},
+            "defaultPage": {{ "size": "A4", "margin": {{ "top": 50, "right": 50, "bottom": 50, "left": 50 }}, "wrap": true }},
+            "defaultStyle": {{ "fontFamily": "TestSans", "fontSize": 11 }},
+            "fonts": [{{ "family": "TestSans", "src": "data:font/ttf;base64,{font_b64}", "weight": 400, "italic": false }}]{extra_document_fields}
+        }}"#
+    )
+}
+
+fn base_fonts(pdf: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(pdf);
+    let mut fonts: Vec<String> = Vec::new();
+    for m in text.split("/BaseFont /").skip(1) {
+        let name: String = m
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == '+' || *c == ',')
+            .collect();
+        if !fonts.contains(&name) {
+            fonts.push(name);
+        }
+    }
+    fonts
+}
+
+#[test]
+fn sentinel_page_numbers_stay_in_the_custom_font() {
+    let pdf = forme::render_json(&sentinel_test_doc("")).expect("renders");
+    let fonts = base_fonts(&pdf);
+    assert!(
+        !fonts.iter().any(|f| f.contains("Helvetica")),
+        "page-number digits must use the footer's font, not base-14 Helvetica; got {fonts:?}"
+    );
+    assert!(
+        fonts.iter().any(|f| f.contains("TestSans")),
+        "the custom font must be present; got {fonts:?}"
+    );
+}
+
+#[test]
+fn sentinel_digits_are_subset_and_text_mapped() {
+    // Digits 0-9 must be in the embedded subset (else the substituted
+    // page numbers render as .notdef) and in ToUnicode (else extraction
+    // loses them — load-bearing for PDF/A-2u and PDF/UA).
+    let pdf = forme::render_json(&sentinel_test_doc("")).expect("renders");
+    let streams = decompress_pdf_streams(&pdf);
+    for digit in ["<0031>", "<0032>"] {
+        assert!(
+            streams.contains(digit),
+            "ToUnicode must map the page-number digits (missing {digit})"
+        );
+    }
+}
+
+#[test]
+fn sentinel_page_numbers_survive_pdfa_and_pdfua() {
+    // The reporter's hard-failure case: an all-embedded document using
+    // page numbering must stay PDF/A + PDF/UA eligible.
+    let json = sentinel_test_doc(r#", "pdfa": "2a", "pdfUa": true"#);
+    let result = forme::render_json(&json);
+    assert!(
+        result.is_ok(),
+        "PDF/A + UA with custom-font page numbers must render: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn sentinel_run_path_comma_chain_stays_in_first_family() {
+    // The multi-style TextRun path resolves comma chains per character —
+    // same bug, different code path. The sentinel must adopt the chain's
+    // first registered family, not fall through to Helvetica.
+    let font_b64 = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        include_bytes!("../fonts/NotoSans-Regular.ttf"),
+    );
+    let json = format!(
+        r#"{{
+            "children": [
+                {{ "kind": {{ "type": "Fixed", "position": "Footer" }}, "style": {{}}, "children": [
+                    {{ "kind": {{ "type": "Text", "content": "", "runs": [
+                        {{ "content": "Page ", "style": {{ "fontFamily": "TestSans, Helvetica" }} }},
+                        {{ "content": "{{{{pageNumber}}}}", "style": {{ "fontFamily": "TestSans, Helvetica" }} }}
+                    ] }}, "style": {{ "fontSize": 9 }}, "children": [] }}
+                ]}},
+                {{ "kind": {{ "type": "Text", "content": "body" }}, "style": {{ "fontFamily": "TestSans", "marginBottom": 900 }}, "children": [] }},
+                {{ "kind": {{ "type": "Text", "content": "page two" }}, "style": {{ "fontFamily": "TestSans" }}, "children": [] }}
+            ],
+            "metadata": {{}},
+            "defaultPage": {{ "size": "A4", "margin": {{ "top": 50, "right": 50, "bottom": 50, "left": 50 }}, "wrap": true }},
+            "fonts": [{{ "family": "TestSans", "src": "data:font/ttf;base64,{font_b64}", "weight": 400, "italic": false }}]
+        }}"#
+    );
+    let pdf = forme::render_json(&json).expect("renders");
+    let fonts = base_fonts(&pdf);
+    assert!(
+        !fonts.iter().any(|f| f.contains("Helvetica")),
+        "run-path sentinel must stay in the chain's first family; got {fonts:?}"
+    );
+}
+
+#[test]
+fn sentinel_default_font_documents_are_unchanged() {
+    // THE WALL: every existing user is on the default-font path. A
+    // default-font document with page numbers must keep exactly one
+    // font — Helvetica — as before. (Byte identity against the pre-fix
+    // binary is verified out-of-band in the fix commit.)
+    let json = r#"{
+        "children": [
+            { "kind": { "type": "Fixed", "position": "Footer" }, "style": {}, "children": [
+                { "kind": { "type": "Text", "content": "Page {{pageNumber}} of {{totalPages}}" }, "style": { "fontSize": 9 }, "children": [] }
+            ]},
+            { "kind": { "type": "Text", "content": "body" }, "style": { "marginBottom": 900 }, "children": [] },
+            { "kind": { "type": "Text", "content": "second page body" }, "style": {}, "children": [] }
+        ],
+        "metadata": {},
+        "defaultPage": { "size": "A4", "margin": { "top": 50, "right": 50, "bottom": 50, "left": 50 }, "wrap": true }
+    }"#;
+    let pdf = forme::render_json(json).expect("renders");
+    let fonts = base_fonts(&pdf);
+    assert_eq!(
+        fonts,
+        vec!["Helvetica".to_string()],
+        "default-font documents must keep exactly Helvetica"
     );
 }

--- a/html/tests/sentinel_font.rs
+++ b/html/tests/sentinel_font.rs
@@ -1,0 +1,60 @@
+//! Page counters in margin boxes must not change the font.
+//!
+//! `counter(page)` compiles to the engine's `{{pageNumber}}` sentinel.
+//! With a provided font (`options.fonts` / `--font`), the sentinel used
+//! to fall through coverage-based font fallback into base-14 Helvetica —
+//! splitting the running footer across two typefaces and breaking
+//! PDF/A eligibility. Same engine bug as the JSX path; this pins the
+//! HTML shape (margin box + provided font), which is the common one.
+
+use forme_pdf_html::{render_html, FontSpec, HtmlOptions};
+
+const NOTO: &[u8] = include_bytes!("../../engine/fonts/NotoSans-Regular.ttf");
+
+fn options_with_test_font() -> HtmlOptions {
+    HtmlOptions {
+        fonts: vec![FontSpec {
+            family: "TestSans".to_string(),
+            data: NOTO.to_vec(),
+            weight: 400,
+            italic: false,
+        }],
+        ..Default::default()
+    }
+}
+
+fn base_fonts(pdf: &[u8]) -> Vec<String> {
+    let text = String::from_utf8_lossy(pdf);
+    let mut fonts: Vec<String> = Vec::new();
+    for m in text.split("/BaseFont /").skip(1) {
+        let name: String = m
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == '+' || *c == ',')
+            .collect();
+        if !fonts.contains(&name) {
+            fonts.push(name);
+        }
+    }
+    fonts
+}
+
+#[test]
+fn margin_box_page_counter_stays_in_the_provided_font() {
+    let html = "<html><head><style>\
+         @page { size: A4; margin: 50pt; \
+                 @bottom-center { content: \"Page \" counter(page) \" of \" counter(pages); \
+                                  font-family: TestSans; font-size: 9pt } } \
+         body { font-family: TestSans; margin: 0 } p { margin: 0 0 600pt 0 }\
+         </style></head><body><p>first page</p><p>second page</p></body></html>";
+    let out = render_html(html, &options_with_test_font()).expect("renders");
+    assert!(out.warnings.is_empty(), "in-subset: {:?}", out.warnings);
+    let fonts = base_fonts(&out.pdf);
+    assert!(
+        !fonts.iter().any(|f| f.contains("Helvetica")),
+        "counter(page) digits must use the margin box's provided font; got {fonts:?}"
+    );
+    assert!(
+        fonts.iter().any(|f| f.contains("TestSans")),
+        "the provided font must be present; got {fonts:?}"
+    );
+}


### PR DESCRIPTION
## The bug

`{{pageNumber}}` / `{{totalPages}}` in a footer set in a registered custom font rendered the substituted digits in **base-14 Helvetica** — one line of text in two typefaces, a second non-embedded `/BaseFont` in the page resources, and a hard failure under `pdfa` + `pdfUa` ("PDF/A requires all fonts to be embedded, but 'Helvetica' is not").

**Root cause:** placeholders become sentinel chars (U+0002/U+0003) at layout time and real digits at write time. No font has a glyph for a control char, so coverage-based per-character font fallback always shunted the sentinel into the terminal Helvetica fallback. Default-font documents never noticed because the fallback equaled the surrounding font.

**A second, latent bug sat behind it:** `collect_font_usage` recorded the sentinel char into the font's subset but not the digits that replace it. Fixing segmentation alone would have turned visible-wrong-font into invisible `.notdef` page numbers — the two fixes land together.

## The fix (engine only; no `@formepdf/react`/`core` changes)

1. **Sentinels are font-neutral in fallback resolution.** `segment_by_font`'s single-family fast path exempts them like whitespace; `resolve_for_char` gets an early guard returning the first *registered* family in the chain (presence, not coverage) — covering both the segmentation slow path and the multi-style TextRun comma-chain path.
2. **Digits 0–9 are subset for any font that carried a sentinel**, so write-time substitution finds real glyphs and ToUnicode maps them (keeps text extraction working — load-bearing for PDF/A-2u and PDF/UA).

## The wall

Default-font documents are **byte-identical** before and after: a default-font placeholder doc rendered by a main-built binary vs this branch `cmp`s equal (sha `d9114cd61c98`), and the suite pins the shape (`sentinel_default_font_documents_are_unchanged`: exactly one `/BaseFont`, Helvetica). Full suites unchanged: engine 541, html 152.

## Tests (fails-first, CI-safe — committed builtin font bytes registered under a custom family)

- Custom-font footer with placeholders → no `/Helvetica`, custom font present
- Digits present in the embedded subset + ToUnicode (`.notdef` regression pin)
- The reporter's `pdfa="2a"` + `pdfUa` case renders
- TextRun comma-chain path (same bug, different code path)
- HTML `counter(page)` in a margin box with a provided font — the launch-relevant shape; verified red without the fix with the exact reported symptom `["Helvetica", "TestSans"]`

Also fixes a latent bug in the `decompress_pdf_streams` test helper: its `"stream\n"` needle matched the tail of `"endstream\n"`, silently skipping every stream after a binary font-file stream — several existing assertions get strictly stronger.

**Named boundary:** a registered font genuinely lacking digit glyphs still renders `.notdef` page numbers, like any other missing glyph. Documented; a warning is a later nicety.