### PR TITLE
Fold table-layout work into the unpublished 0.18.0 changelog

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -8,7 +8,7 @@ Full release notes live on **[GitHub Releases](https://github.com/formepdf/forme
 
 ## Recent highlights
 
-- **0.18.0** — PDF/A-3 (3b/3u/3a) and Factur-X/ZUGFeRD e-invoice containers: one render call produces the human-readable invoice PDF and embeds your EN 16931 XML as a conformant associated file, CI-validated by veraPDF and Mustangproject. [Docs](/einvoicing). Includes a correction: `embedData` under PDF/A-2 now errors by name — such files were never valid PDF/A-2.
+- **0.18.0** — PDF/A-3 (3b/3u/3a) and Factur-X/ZUGFeRD e-invoice containers: one render call produces the human-readable invoice PDF and embeds your EN 16931 XML as a conformant associated file, CI-validated by veraPDF and Mustangproject. [Docs](/einvoicing). Also: automatic table layout (banner-row tables no longer collapse — found by a 15-template real-world audit), a new render-defect warning channel, and warning dedup. Two corrections: `embedData` under PDF/A-2 now errors by name (such files were never valid PDF/A-2), and tables relying on the old first-row column inference re-render correctly.
 - **0.17.0** — CSS Paged Media page selection: `@page :left`/`:right` and named pages (`@page <name>` + the `page` property) in the HTML path; CSS Grid through the HTML mapper; page-number placeholders no longer switch fonts (custom-font footers stay PDF/A-eligible); ~2× fewer allocations in large-document layout.
 - **0.16.0** — PDF/A-2 conformance (levels 2b, 2u, 2a), veraPDF-verified in CI, composing with PDF/UA-1. Includes a correction: `pdfa` output from earlier versions was not valid PDF/A — [re-render guidance here](/archival).
 - **0.15.0** — Vue 3 adapter, `@formepdf/fonts-standard`, PDF/UA-1 verification as a veraPDF CI gate, and browser/Workers builds of the HTML engine.

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.18.0] - 2026-09-03
 
 ### Fixed
 
@@ -9,12 +9,6 @@
 ### Added
 
 - **The render-defect channel.** Warnings that answer "what did WE get wrong?" (vs. the subset contract's "what did you ask for that we don't support?"). First entries: table columns clamped when fixed widths exceed the available width, and columns forced below min-content when content genuinely cannot fit. Prefixed `render defect:` and surfaced through the existing warnings stream; layout-stage warnings now flow into render output alongside the writer's.
-
-
-## [0.18.0] - 2026-09-03
-
-### Added
-
 - **PDF/A-3 (3b/3u/3a).** Identical rule set to PDF/A-2 plus permission for arbitrary embedded files (verified against the veraPDF part-2/3 rules — the only deltas are clause 6.8). XMP `pdfaid:part` 3; `3a` implies tagging like `2a`.
 - **Attachments (associated files).** `Document.attachments` embeds files with the PDF/A-3 requirements built in: MIME `/Subtype` on the stream, `/F` + `/UF` + `/AFRelationship` on the filespec, `/Params` with `/Size` and a **deterministic** default `/ModDate` (never wall-clock — byte determinism holds), and membership in the catalog `/AF` array.
 - **Factur-X / ZUGFeRD e-invoice container.** `Document.zugferd` emits the `fx:` XMP identification (DocumentType/DocumentFileName/Version/ConformanceLevel, namespace `urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#`) with the required PDF/A extension-schema description; `/AFRelationship` defaults per profile (`Data` for MINIMUM/BASIC WL, `Alternative` otherwise). Composes with `pdf_ua`. Container only — the engine does not generate or validate the invoice XML.

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — @formepdf/html
 
-## [Unreleased]
+## [0.18.0] - 2026-09-03
 
 ### Fixed
 
@@ -10,11 +10,6 @@
 
 - **Warning dedup.** Identical warnings collapse to one entry carrying a count ("float is not supported … (×214)"). Framework stylesheets previously produced thousands of identical lines (AdminLTE: 6,905) that drowned the signal.
 - Render-defect warnings from the engine (`render defect:` prefix) now surface: silent in-scope layout failures — the gap the template-compat experiment exposed — report themselves.
-
-
-## [0.18.0] - 2026-09-03
-
-### Added
 
 - `pdfA` accepts `"3b"`, `"3u"`, `"3a"` (PDF/A-3 — same rules as part 2 plus permission for embedded files). The whole corpus is veraPDF-gated at 3b/3a alongside 2b/2a.
 


### PR DESCRIPTION
0.18.0 was bumped and built but never published, so PR #37's table auto-layout, render-defect channel, and warning dedup ship in it. This merges the [Unreleased] changelog sections into [0.18.0] (engine + @formepdf/html) and updates the docs highlight to name both behavior corrections (PDF/A-2 embedData refusal; table re-rendering under automatic layout). Docs only.