### PR TITLE
Fix the "Thk ft" garble (absolute margin anchoring) + table section ordering

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
-### Fixed
+### Changed (behavior — absolutely-positioned layout may shift)
 
-- **`bottom`/`right` absolute offsets anchor the margin edge, per CSS.** The border box was anchored and margins applied afterward, so `position:absolute; bottom:0` plus a `margin-top` shoved the content past the anchor — a receipt footer rendered below the page bottom with only ascender tips visible ("Thk ft", the template corpus's one silent text defect; it looked like a font bug and was actually geometry).
+- **`bottom`/`right` offsets on `position: absolute` now anchor the margin edge, per CSS.** Previously they anchored the border box and margins were applied afterward, so any absolutely-positioned element combining a `bottom` or `right` offset with margins rendered past its anchor — by exactly its vertical (for `bottom`) or horizontal (for `right`) margin sum. This is a CSS conformance fix, not a subset change.
+
+  **If your layout shifted after upgrading:** elements with `bottom`/`right` offsets AND margins now sit closer to the top-left by their margin size — that's the spec-correct position. Elements using `top`/`left` anchors, or no margins, are unaffected. How it was found: a receipt footer with `bottom: 0; margin-top: 1rem` rendered 12pt below the page bottom, leaving only the ascender tips of "Thank you for your payment." visible ("Thk ft" — it looked like a font bug and was geometry).
+
+### Fixed
 - **Table intrinsic width.** `measure_intrinsic_width` / `measure_min_content_width` had no `Table` arm, so a shrink-to-fit container holding a table measured as its widest single cell and crushed the table to one column's width (per-word vertical text). Tables now measure as the sum of per-column max/min content, colspan-aware. Related to 0.18.0's automatic-table-layout fix — the second instance of intrinsic-width measurement disagreeing with layout, surfaced from a different direction.
 - **Flex-wrap epsilon.** Percentage widths pass through `f32`, so 60% + 40% of a row could sum to a hair over 100% and spuriously wrap. Line partitioning now tolerates 0.01pt.
 - **Row-measure double percent resolution.** The Row arm of `measure_node_height` resolved each child's style against the child's own final width instead of the container's, so `width: 27%` became 27% *of* 27% — text measured at a quarter width, one word per line, and rows measured 2.5–4× taller than layout produced (phantom vertical gaps below flex rows). Third confirmed instance of the measure/layout-disagreement family.

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- **`bottom`/`right` absolute offsets anchor the margin edge, per CSS.** The border box was anchored and margins applied afterward, so `position:absolute; bottom:0` plus a `margin-top` shoved the content past the anchor — a receipt footer rendered below the page bottom with only ascender tips visible ("Thk ft", the template corpus's one silent text defect; it looked like a font bug and was actually geometry).
 - **Table intrinsic width.** `measure_intrinsic_width` / `measure_min_content_width` had no `Table` arm, so a shrink-to-fit container holding a table measured as its widest single cell and crushed the table to one column's width (per-word vertical text). Tables now measure as the sum of per-column max/min content, colspan-aware. Related to 0.18.0's automatic-table-layout fix — the second instance of intrinsic-width measurement disagreeing with layout, surfaced from a different direction.
 - **Flex-wrap epsilon.** Percentage widths pass through `f32`, so 60% + 40% of a row could sum to a hair over 100% and spuriously wrap. Line partitioning now tolerates 0.01pt.
 - **Row-measure double percent resolution.** The Row arm of `measure_node_height` resolved each child's style against the child's own final width instead of the container's, so `width: 27%` became 27% *of* 27% — text measured at a quarter width, one word per line, and rows measured 2.5–4× taller than layout produced (phantom vertical gaps below flex rows). Third confirmed instance of the measure/layout-disagreement family.

--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -2807,11 +2807,18 @@ impl LayoutEngine {
                 }
             };
 
-            // Position relative to the containing block.
+            // Position relative to the containing block. Per CSS, the
+            // offsets position the MARGIN edge: layout_node applies
+            // margin.top/left inside the slot, so a top/left anchor needs
+            // no adjustment — but bottom/right anchors must reserve the
+            // margins, or a margin shoves the border box past the anchor
+            // (template-compat 15: `bottom:0` + `margin-top:1rem` pushed a
+            // footer off the page bottom, leaving only ascender tips).
+            let abs_margin = abs_style.margin.to_edges();
             let abs_x = if let Some(l) = abs_style.left {
                 cb_x + l
             } else if let Some(r) = abs_style.right {
-                cb_x + cb_w - r - child_width
+                cb_x + cb_w - r - child_width - abs_margin.horizontal()
             } else {
                 cb_x
             };
@@ -2819,7 +2826,7 @@ impl LayoutEngine {
             let abs_y = if let Some(t) = abs_style.top {
                 cb_y + t
             } else if let Some(b) = abs_style.bottom {
-                cb_y + cb_h - b - child_height
+                cb_y + cb_h - b - child_height - abs_margin.vertical()
             } else {
                 cb_y
             };

--- a/html/src/map.rs
+++ b/html/src/map.rs
@@ -859,6 +859,7 @@ impl Mapper {
         };
         let mut rows: Vec<Node> = Vec::new();
         let mut next_row = 0usize;
+        let mut seen_thead = false;
         self.collect_rows(
             &el.children,
             computed.font_size,
@@ -866,6 +867,7 @@ impl Mapper {
             &mut rows,
             &table_info,
             &mut next_row,
+            &mut seen_thead,
         );
 
         // Column definitions from the first row's cell widths. Mixed
@@ -880,6 +882,7 @@ impl Mapper {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn collect_rows(
         &mut self,
         children: &[DomNode],
@@ -888,10 +891,29 @@ impl Mapper {
         rows: &mut Vec<Node>,
         table_info: &TableInfo,
         next_row: &mut usize,
+        seen_thead: &mut bool,
     ) {
-        for child in children {
+        // <tfoot> renders at the BOTTOM of the table regardless of where
+        // it sits in the markup (HTML allows and templates commonly use
+        // tfoot before tbody so streaming renderers see it early) — so
+        // walk every non-tfoot child first, then the tfoots. RowPos is
+        // assigned in this visual order, keeping first/last aligned with
+        // what actually renders (border-collapse edge ownership).
+        let is_tfoot = |c: &&DomNode| matches!(c, DomNode::Element(e) if e.tag == "tfoot");
+        let ordered = children
+            .iter()
+            .filter(|c| !is_tfoot(c))
+            .chain(children.iter().filter(is_tfoot));
+        for child in ordered {
             match child {
                 DomNode::Element(e) if e.tag == "tr" => {
+                    // display:none must mean hidden here too — this path
+                    // bypasses map_block_element's check, and templates
+                    // hide rows they expect JS (which we don't run) to
+                    // reveal.
+                    if self.computed_for(e, font_size).display == CssDisplay::None {
+                        continue;
+                    }
                     let row_pos = RowPos {
                         first: *next_row == 0,
                         last: *next_row + 1 == table_info.total_rows,
@@ -905,11 +927,25 @@ impl Mapper {
                     // than silently accepting it. Row-level break-inside
                     // IS honored: rows are atomic by engine design.
                     let section_computed = self.computed_for(e, font_size);
+                    if section_computed.display == CssDisplay::None {
+                        continue;
+                    }
                     if section_computed.break_inside.is_some() {
                         self.warnings.push(format!(
                             "break-inside on <{}> is pending (rows are already atomic; put break-inside: avoid on the table to keep the whole table together)",
                             e.tag
                         ));
+                    }
+                    // Per HTML, only the FIRST thead is the table header;
+                    // a later thead is an ordinary row group in DOM
+                    // order. The engine hoists header rows to the top and
+                    // repeats them per page, so marking a late thead as
+                    // header printed a totals block above the line items
+                    // (template-compat 08 keeps its totals in a second
+                    // thead after tbody).
+                    let is_header = e.tag == "thead" && !*seen_thead;
+                    if e.tag == "thead" {
+                        *seen_thead = true;
                     }
                     // The section element is a selector ancestor
                     // (`tbody tr:nth-child(even)` — the zebra idiom).
@@ -917,10 +953,11 @@ impl Mapper {
                     self.collect_rows(
                         &e.children,
                         font_size,
-                        e.tag == "thead",
+                        is_header,
                         rows,
                         table_info,
                         next_row,
+                        seen_thead,
                     );
                     self.stack.pop();
                 }

--- a/html/tests/absolute.rs
+++ b/html/tests/absolute.rs
@@ -1,0 +1,101 @@
+//! Absolute positioning — fails-first pins from the template corpus.
+
+use forme::layout::ElementInfo;
+use forme_pdf_html::{render_html_with_layout, HtmlLayoutOutput, HtmlOptions};
+
+fn render(html: &str) -> HtmlLayoutOutput {
+    render_html_with_layout(html, &HtmlOptions::default()).expect("must render")
+}
+
+fn walk<'a>(elements: &'a [ElementInfo], f: &mut impl FnMut(&'a ElementInfo)) {
+    for el in elements {
+        f(el);
+        walk(&el.children, f);
+    }
+}
+
+fn line(out: &HtmlLayoutOutput, needle: &str) -> (f64, f64) {
+    let mut hit = None;
+    for page in &out.layout.pages {
+        walk(&page.elements, &mut |el| {
+            if hit.is_none() && el.node_type == "TextLine" {
+                if let Some(t) = &el.text_content {
+                    if t.contains(needle) {
+                        hit = Some((el.y, el.height));
+                    }
+                }
+            }
+        });
+    }
+    hit.unwrap_or_else(|| panic!("no text line containing {needle:?}"))
+}
+
+#[test]
+fn bottom_anchored_margin_box_stays_on_the_page() {
+    // The template-compat 15 shape: A5 landscape (content height 419.5pt
+    // with zero vertical @page margins), a footer with
+    // `position:absolute; bottom:0` AND `margin-top:1rem`. Per CSS,
+    // `bottom` positions the MARGIN edge — the margin must not shove the
+    // content past the anchor. The bug rendered the footer 12pt below
+    // the page bottom, leaving only ascender tips visible ("Thk ft" —
+    // the corpus's one silent text defect).
+    let out = render(
+        "<html><head><style>\
+         @page { size: A5 landscape; margin-top: 0; margin-bottom: 0 }\
+         body { margin: 0 }\
+         </style></head><body>\
+         <p style=\"margin:0\">content</p>\
+         <div style=\"position:absolute; bottom:0; width:100%; margin-top:12pt\">\
+           <p style=\"margin:0\">Thank you for your payment.</p>\
+         </div></body></html>",
+    );
+    let content_h = 419.53; // A5 landscape height, zero vertical margins
+    let (y, h) = line(&out, "Thank you");
+    assert!(
+        y + h <= content_h + 0.5,
+        "footer bottom {:.1} must not pass the content bottom {content_h}",
+        y + h
+    );
+    // The margin-box bottom sits at the anchor, so the text bottom sits
+    // exactly at the content bottom (zero margin-bottom).
+    assert!(
+        (y + h - content_h).abs() < 1.5,
+        "footer should sit flush at the anchor: bottom {:.1} vs {content_h}",
+        y + h
+    );
+}
+
+#[test]
+fn right_anchored_margin_box_respects_its_margin() {
+    // Horizontal twin: `right: 0` positions the margin edge, so a
+    // margin-left must not shove the box past the right edge.
+    let out = render(
+        "<html><head><style>body { margin: 0 }</style></head><body>\
+         <div style=\"position:relative; width: 400pt; height: 100pt\">\
+           <div style=\"position:absolute; right:0; top:0; width:100pt; margin-left:20pt\">\
+             <p style=\"margin:0\">badge</p>\
+           </div>\
+         </div></body></html>",
+    );
+    let mut badge = None;
+    for page in &out.layout.pages {
+        walk(&page.elements, &mut |el| {
+            if badge.is_none() && el.node_type == "TextLine" {
+                if let Some(t) = &el.text_content {
+                    if t.contains("badge") {
+                        badge = Some((el.x, el.width));
+                    }
+                }
+            }
+        });
+    }
+    let (x, _) = badge.expect("badge line");
+    // Container starts at content x = 54 (A4 default margins), width
+    // 400: right edge at 454. A 100pt box anchored right ends at 454,
+    // so its text starts at 354 — the margin-left must not push it to
+    // 374 (past the anchor).
+    assert!(
+        x <= 354.5,
+        "right-anchored box must end at the anchor; text starts at {x:.1}, expected ~354"
+    );
+}

--- a/html/tests/table_layout.rs
+++ b/html/tests/table_layout.rs
@@ -109,3 +109,109 @@ fn duplicate_warnings_collapse_with_a_count() {
         shadow_warnings[0]
     );
 }
+
+// ── tfoot renders at the bottom regardless of DOM position ─────────
+
+#[test]
+fn tfoot_before_tbody_renders_last() {
+    // The niraj-invoice shape (template-compat 08): markup puts <tfoot>
+    // (Subtotal/Total) BEFORE <tbody> — browsers render tfoot at the
+    // bottom of the table regardless of DOM position; we rendered it in
+    // DOM order, printing the totals above the line items.
+    let out = render(
+        "<html><body><table>\
+           <thead><tr><th>Item</th><th>Price</th></tr></thead>\
+           <tfoot><tr><td>Total</td><td>$30</td></tr></tfoot>\
+           <tbody>\
+             <tr><td>Widget</td><td>$10</td></tr>\
+             <tr><td>Gadget</td><td>$20</td></tr>\
+           </tbody>\
+         </table></body></html>",
+    );
+    let y_of = |needle: &str| -> f64 {
+        let mut hit = None;
+        for page in &out.layout.pages {
+            walk(&page.elements, &mut |el| {
+                if hit.is_none() && el.node_type == "TextLine" {
+                    if let Some(t) = &el.text_content {
+                        if t.contains(needle) {
+                            hit = Some(el.y);
+                        }
+                    }
+                }
+            });
+        }
+        hit.unwrap_or_else(|| panic!("no line containing {needle:?}"))
+    };
+    let header = y_of("Item");
+    let widget = y_of("Widget");
+    let gadget = y_of("Gadget");
+    let total = y_of("Total");
+    assert!(header < widget, "thead first");
+    assert!(widget < gadget, "body rows in order");
+    assert!(
+        gadget < total,
+        "tfoot renders below the body rows (Total at {total:.0}, Gadget at {gadget:.0})"
+    );
+}
+
+#[test]
+fn display_none_rows_and_sections_do_not_render() {
+    // The niraj template hides its totals rows with display:none and
+    // un-hides them with JS. We don't run JS (constitution), so hidden
+    // must mean hidden — collect_rows previously bypassed the
+    // display:none check that every other element gets.
+    let out = render(
+        "<html><body><table>\
+           <tr><td>visible row</td></tr>\
+           <tr style=\"display: none\"><td>hidden row</td></tr>\
+           <thead style=\"display: none\"><tr><td>hidden section</td></tr></thead>\
+         </table></body></html>",
+    );
+    assert!(!text_lines_containing(&out, "visible row").is_empty());
+    assert!(
+        text_lines_containing(&out, "hidden row").is_empty(),
+        "display:none row must not render"
+    );
+    assert!(
+        text_lines_containing(&out, "hidden section").is_empty(),
+        "display:none section must not render"
+    );
+}
+
+#[test]
+fn second_thead_stays_in_dom_order() {
+    // Per HTML, only the FIRST thead is the table header; a later thead
+    // is an ordinary row group in DOM order. The engine hoists header
+    // rows to the top (and repeats them per page), so marking a late
+    // thead as header printed a totals block ABOVE the line items
+    // (template-compat 08's actual shape — its "totals" live in a
+    // second thead after tbody, not a tfoot).
+    let out = render(
+        "<html><body><table>\
+           <thead><tr><th>Item</th></tr></thead>\
+           <tbody><tr><td>Widget</td></tr></tbody>\
+           <thead class=\"totals\"><tr><td>Total</td></tr></thead>\
+         </table></body></html>",
+    );
+    let y_of = |needle: &str| -> f64 {
+        let mut hit = None;
+        for page in &out.layout.pages {
+            walk(&page.elements, &mut |el| {
+                if hit.is_none() && el.node_type == "TextLine" {
+                    if let Some(t) = &el.text_content {
+                        if t.contains(needle) {
+                            hit = Some(el.y);
+                        }
+                    }
+                }
+            });
+        }
+        hit.unwrap_or_else(|| panic!("no line containing {needle:?}"))
+    };
+    assert!(y_of("Item") < y_of("Widget"), "first thead is the header");
+    assert!(
+        y_of("Widget") < y_of("Total"),
+        "a second thead renders in DOM order, not hoisted"
+    );
+}

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed (table sections + absolute positioning)
+
+- **`<tfoot>` renders at the bottom of the table** regardless of where it sits in the markup — HTML allows (and templates commonly use) tfoot before tbody so streaming renderers see it early; it previously rendered in DOM order.
+- **Only the first `<thead>` is the repeating table header.** A later thead is an ordinary row group in DOM order, per HTML — previously its rows were hoisted to the top of the table (a totals block kept in a second thead printed above the line items).
+- **`display: none` now applies to table rows and sections.** The row-collection path bypassed the check every other element gets, so rows a template hides for JS to reveal (which we don't run) rendered anyway.
+- **`bottom`/`right`-anchored absolute boxes respect their margins** (engine fix — a `bottom:0` footer with a `margin-top` rendered past the page bottom, leaving only ascender tips: the corpus's "Thk ft").
+
 ### Fixed (measure/layout agreement — phantom vertical gaps)
 
 - **Flex rows with percent-width children no longer reserve phantom height** (rows measured 2.5–4× taller than their content when children carried percent widths — visible as large gaps below float rows and flex headers).

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **`<tfoot>` renders at the bottom of the table** regardless of where it sits in the markup — HTML allows (and templates commonly use) tfoot before tbody so streaming renderers see it early; it previously rendered in DOM order.
 - **Only the first `<thead>` is the repeating table header.** A later thead is an ordinary row group in DOM order, per HTML — previously its rows were hoisted to the top of the table (a totals block kept in a second thead printed above the line items).
 - **`display: none` now applies to table rows and sections.** The row-collection path bypassed the check every other element gets, so rows a template hides for JS to reveal (which we don't run) rendered anyway.
-- **`bottom`/`right`-anchored absolute boxes respect their margins** (engine fix — a `bottom:0` footer with a `margin-top` rendered past the page bottom, leaving only ascender tips: the corpus's "Thk ft").
+- **`bottom`/`right`-anchored absolute boxes respect their margins** — a behavior change: CSS offsets position the *margin edge*, and we anchored the border box, so any `position:absolute` element with a `bottom`/`right` offset and margins rendered past its anchor by the margin size. If a positioned element sits higher/further left after upgrading, that's the spec-correct spot (a `bottom:0` footer with `margin-top` previously rendered past the page bottom, leaving only ascender tips: the corpus's "Thk ft"). Engine fix — see `engine/CHANGELOG.md`.
 
 ### Fixed (measure/layout agreement — phantom vertical gaps)
 


### PR DESCRIPTION
## The corpus's one silent text defect, diagnosed

Template 15's footer rendered as "Thk ft". It looked like a font/shaping bug and was actually **geometry**: `position:absolute; bottom:0` anchored the border box and applied `margin-top` afterward, pushing the footer 12pt past the A5-landscape page bottom — only the ascender tips of "Thank you for your payment." stayed visible. Per CSS, the offsets position the **margin edge**; `bottom`/`right` anchors now reserve the margins (`top`/`left` were already correct since layout applies margins inside the slot).

## Template 08's totals-above-items, which was three bugs

- **`<tfoot>` renders at the bottom** of the table regardless of DOM position (templates put it early for streaming renderers); previously DOM order
- **Only the first `<thead>` is the repeating header** — 08 actually keeps its totals in a *second* `<thead class="totals">` after tbody, which we hoisted to the top; per HTML a later thead is an ordinary row group in DOM order
- **`display:none` now applies to rows and sections** — the row-collection path bypassed the check every other element gets, so rows hidden for JS to reveal (we don't run JS) rendered anyway

## Evidence

- 5 fails-first pins (`tests/absolute.rs`: bottom + right anchors; `tests/table_layout.rs`: tfoot order, second-thead, display:none)
- Measured on the corpus: 15's footer complete and on-page; 08 renders items then Total (Chrome order) with the JS-gated Subtotal/Tax rows correctly hidden
- Byte wall RUN via `scripts/byte-wall.sh` vs main: all 6 fixtures IDENTICAL
- Engine 558/0, html 174/0, clippy clean