### PR TITLE
READMEs: measured real-template claim + retire the stale Status section

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -131,6 +131,16 @@ positions in both engines — `break-after` isolating the summary page,
 legacy alias opening its own page. Frozen reference:
 `tests/fixtures/report.chrome-reference.pdf`.
 
+**Verified against real-world templates**: 15 production templates
+collected from GitHub — Bootstrap 2/3 float grids, mPDF- and
+wkhtmltopdf-era table layouts, nested-table email HTML, modern CSS grid
+— none written with this engine in mind. Measured against Chrome print
+output: **11 of 15 render correctly; the other 4 degrade legibly with
+every cause named in `warnings`; zero render broken.** The four
+degraded cases share known causes (a `position: running()` stray, an
+admin-shell sidebar, and two templates whose grids only activate above
+a 768px viewport — a media-query semantics question, not a layout gap).
+
 **How this compares.** wkhtmltopdf (archived 2023) and DomPDF never
 shipped margin boxes or reliable break control. Chrome only gained
 margin-box generated content in Chrome 131 (late 2024) and still requires
@@ -185,5 +195,7 @@ document embed.
 
 ## Status
 
-Pre-release (`0.0.x`), Rust API + CLI. The npm package (`@formepdf/html`,
-WASM — Node, browser, edge) is the packaging phase of the roadmap.
+Shipping. The npm package
+([`@formepdf/html`](https://www.npmjs.com/package/@formepdf/html) —
+Node, browser, workers/edge, WASM) publishes on the monorepo's shared
+version line alongside the Rust API and the `forme-html` CLI.

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -29,7 +29,17 @@ they still haven't:
   `page-break-*` spellings every wkhtmltopdf-era template still carries
 - **`orphans` / `widows`**, `<thead>` repetition on every page
 - Stylesheets with a documented selector subset, the full cascade with
-  `!important`, flexbox, tables with colspan/rowspan, lists, images
+  `!important`, flexbox, a CSS Grid subset, tables with colspan/rowspan,
+  lists, images
+- **Floats as column rows** — `float: left/right` + `clear` lay
+  consecutive floated siblings out as a row (the Bootstrap `col-*` and
+  left/right header-pair shape real templates use); only true
+  text-wrapping alongside a float is out, and it warns
+
+Measured against 15 real production templates from GitHub (Bootstrap
+2/3 grids, mPDF/wkhtmltopdf-era tables, email HTML, modern CSS grid):
+**11 of 15 render correctly, the other 4 degrade legibly with every
+cause named in `warnings`, zero render broken.**
 
 The complete property-by-property subset table lives in the
 [repository README](https://github.com/formepdf/forme/tree/main/html) —


### PR DESCRIPTION
The honesty sections predate the corpus campaign. Both the crate and npm READMEs now carry the measured claim — 15 real production templates from GitHub (Bootstrap 2/3 float grids, mPDF/wkhtmltopdf-era tables, email HTML, modern CSS grid): **11 render correctly, 4 degrade legibly with every cause named in `warnings`, 0 broken** — and the float caveat is narrowed to what's actually unsupported (text wrapping alongside a float). Also retires the crate README's Status section, which still said "pre-release 0.0.x, npm is the packaging phase of the roadmap" — five releases stale. Docs-only.