### PR TITLE
RELEASE.md: the real-template corpus joins the pre-publish gate

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -280,7 +280,10 @@ cd forme-go && go clean -testcache && go test ./...
 #     github.com/danmolitor/forme-template-compat (7 of 15 templates carry
 #     redistribution constraints — it never joins this repo).
 cd forme/html && cargo build --release             # ALWAYS build fresh first
-cd ../../forme-template-compat && bash run.sh      # sibling checkout; renders forme + Chrome refs
+# forme-template-compat is a sibling of the forme MONOREPO PARENT dir
+# (../../.. from forme/html); its run.sh finds the binary via that layout,
+# or set FORME_HTML to the binary path explicitly.
+cd ../../../forme-template-compat && bash run.sh   # renders forme + Chrome refs
 git diff --stat out/                               # page counts + warnings vs committed snapshots
 #     DISPOSITION — this is the step, not the diff: anything that moved is
 #     one of exactly two things, and you decide which before publishing:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -273,6 +273,24 @@ cd forme/packages/html && npm test                 # WASM smoke
 #   packages/html/bin/forme-html.js, cmp the outputs
 cd forme-go && go clean -testcache && go test ./...
 
+# 3b. Real-template corpus (if engine/ or html/ changed) — the acceptance
+#     measure behind the README's "11 of 15" claim. The pins extracted from
+#     it run in CI; the corpus itself finds the NEXT bug, and only a human
+#     can grade it. Lives in the PRIVATE repo
+#     github.com/danmolitor/forme-template-compat (7 of 15 templates carry
+#     redistribution constraints — it never joins this repo).
+cd forme/html && cargo build --release             # ALWAYS build fresh first
+cd ../../forme-template-compat && bash run.sh      # sibling checkout; renders forme + Chrome refs
+git diff --stat out/                               # page counts + warnings vs committed snapshots
+#     DISPOSITION — this is the step, not the diff: anything that moved is
+#     one of exactly two things, and you decide which before publishing:
+#       * an intended improvement → record it in the release notes and
+#         commit the refreshed out/*.warnings.txt as the new baseline;
+#       * unexplained → a regression until proven otherwise: STOP, do not
+#         publish. "Probably fine" is how layout regressions ship.
+#     No diff = no action. Eyeballing without dispositioning is a rubber
+#     stamp.
+
 # 4. Lockfile must be regenerated after version bumps
 cd forme && npm install
 cd forme && git diff --stat package-lock.json   # should show the @formepdf/* deps moved to the new version


### PR DESCRIPTION
Adds step 3b to the pre-publish gate: render the private template-compat corpus (fresh build first), diff page counts and warnings against the committed snapshots, and **disposition** anything that moved — either an intended improvement (record in release notes, commit the refreshed baseline) or a regression (stop, don't publish). The extracted pins in CI handle the assertable part continuously; the corpus finds the next bug and only a human can grade it, which is why it's a release-ritual step rather than a CI job. Docs-only.