### PR TITLE
position: running() elements are removed from flow, per spec

### DIFF
--- a/html/src/css.rs
+++ b/html/src/css.rs
@@ -125,6 +125,10 @@ pub struct CssStyle {
     pub min_height: Option<Length>,
     pub position_absolute: Option<bool>,
     pub position_relative: Option<bool>,
+    /// `position: running(<ident>)` — out of subset, but per CSS GCPM the
+    /// element leaves normal flow, so the mapper must SUPPRESS it (the
+    /// in-flow render was the bug, not the missing feature).
+    pub position_running: Option<bool>,
     pub top: Option<Length>,
     pub right: Option<Length>,
     pub bottom: Option<Length>,
@@ -219,6 +223,7 @@ impl CssStyle {
             min_height,
             position_absolute,
             position_relative,
+            position_running,
             top,
             right,
             bottom,
@@ -558,9 +563,10 @@ pub(crate) fn apply_declaration(
             if let Ok(cssparser::Token::Function(f)) = &tok {
                 if f.eq_ignore_ascii_case("running") {
                     warnings.push(
-                        "position: running() (running elements) is not supported — use @page margin boxes for running headers/footers"
+                        "position: running() (running elements) is not supported — the element is removed from flow per spec; use @page margin boxes for running headers/footers"
                             .to_string(),
                     );
+                    style.position_running = Some(true);
                 } else {
                     warnings.push(format!("unsupported position value '{f}('"));
                 }

--- a/html/src/map.rs
+++ b/html/src/map.rs
@@ -443,6 +443,14 @@ impl Mapper {
         if computed.display == CssDisplay::None {
             return None;
         }
+        // `position: running()` removes the element from normal flow per
+        // CSS GCPM — it would only appear where a margin box says
+        // `content: element(name)`, which we don't support (warned at
+        // parse time). Rendering it in-flow was the bug: stray header
+        // text at the top of the page (template-compat 02's "Page of").
+        if computed.position_running {
+            return None;
+        }
         let computed_break_after = computed.break_after;
 
         // The element becomes an ancestor for everything mapped inside it.

--- a/html/src/style.rs
+++ b/html/src/style.rs
@@ -86,6 +86,9 @@ pub struct Computed {
     pub min_height: Option<Dimension>,
     pub position_absolute: bool,
     pub position_relative: bool,
+    /// `position: running()` — the element is out of normal flow; the
+    /// mapper drops it (warned at parse time).
+    pub position_running: bool,
     /// Offsets in points, meaningful with `position_absolute` or
     /// `position_relative`.
     pub offsets: [Option<f64>; 4],
@@ -301,6 +304,7 @@ pub fn resolve(css: &CssStyle, parent_font_size: f64, warnings: &mut Vec<String>
         min_height: dim(css.min_height),
         position_absolute: css.position_absolute == Some(true),
         position_relative: css.position_relative == Some(true),
+        position_running: css.position_running == Some(true),
         offsets: {
             // Offsets are meaningful for both absolute and relative; on a
             // static box they're inert (warned).

--- a/html/tests/polish.rs
+++ b/html/tests/polish.rs
@@ -371,3 +371,32 @@ fn border_style_maps_per_side_and_double_falls_back_to_solid() {
     .expect("double still renders");
     assert!(out.pdf.len() > 100 && &out.pdf[0..5] == b"%PDF-");
 }
+
+#[test]
+fn running_position_removes_the_element_from_flow() {
+    // Per CSS GCPM, `position: running(name)` takes the element OUT of
+    // normal flow; it appears only where a margin box says
+    // `content: element(name)`, and simply doesn't display otherwise.
+    // We support neither half, warned by name — but the element still
+    // rendered in-flow, producing stray header text at the top of the
+    // page (template-compat 02's "Page of"). Suppression IS the
+    // spec-conformant floor here.
+    let (doc, warnings) = html_to_document(
+        "<html><head><style>.h { position: running(header) }</style></head><body>\
+         <div class=\"h\">Page of</div>\
+         <p>real content</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(
+        warnings.iter().any(|w| w.contains("running()")),
+        "still warned by name: {warnings:?}"
+    );
+    assert!(
+        text_of(&doc.children, "Page of").is_none(),
+        "running element must not render in flow"
+    );
+    assert!(
+        text_of(&doc.children, "real content").is_some(),
+        "siblings unaffected"
+    );
+}

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed (table sections + absolute positioning)
 
+- **`position: running()` elements no longer render in flow.** Per CSS GCPM the element leaves normal flow entirely (it would only appear where a margin box says `content: element(name)`, which is unsupported) — previously it was warned by name but still rendered in place, producing stray header text at the top of the page. The warning stays and now says the element was removed; `@page` margin boxes are the supported way to get running headers/footers.
+
 - **`<tfoot>` renders at the bottom of the table** regardless of where it sits in the markup — HTML allows (and templates commonly use) tfoot before tbody so streaming renderers see it early; it previously rendered in DOM order.
 - **Only the first `<thead>` is the repeating table header.** A later thead is an ordinary row group in DOM order, per HTML — previously its rows were hoisted to the top of the table (a totals block kept in a second thead printed above the line items).
 - **`display: none` now applies to table rows and sections.** The row-collection path bypassed the check every other element gets, so rows a template hides for JS to reveal (which we don't run) rendered anyway.


### PR DESCRIPTION
Per CSS GCPM, `position: running(name)` takes the element out of normal flow — it appears only where a margin box says `content: element(name)`, and simply doesn't display otherwise. We support neither half and warn by name, but the element still rendered in-flow, producing stray header text at the top of the page (template-compat 02's "Page of"). Suppression is the spec-conformant floor: the in-flow render was the bug, not the missing feature.

- Parse-time warning kept, now says the element was removed and points at `@page` margin boxes as the supported equivalent
- Fails-first pin (warning present, element absent from the document tree, siblings intact)
- Byte wall RUN vs main: all 6 fixtures IDENTICAL; html 182/0, clippy clean; engine untouched
- Corpus: 02's stray gone (its mis-centered street line is a separate cause — still DEGRADED, now for one reason instead of two)