### PR TITLE
Dogfood experiment: surface pdf-testkit's semantic diff in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,22 @@ jobs:
         # vitest.config.ts excludes them — so this is the only step that
         # runs them, and its green check means what its name says rather
         # than re-reporting what `Test Core` already covered.
+        #
+        # Output is teed for the semantic-diff summary step below (the
+        # dogfood experiment); pipefail keeps this step the authoritative
+        # gate exactly as before.
         working-directory: packages/core
-        run: npm run test:templates
+        run: npm run test:templates 2>&1 | tee /tmp/templates-regression.log
+      - name: Semantic diff summary (dogfood experiment, non-gating)
+        # When a baseline mismatches, surface pdf-testkit's semantic diff
+        # (already computed by the matcher) in the job summary instead of
+        # leaving it in log scrollback. Information only — the step above
+        # is the gate; this one cannot fail the build. Remove the
+        # experiment by deleting scripts/semantic-diff-summary.sh and this
+        # step.
+        if: failure()
+        working-directory: packages/core
+        run: bash scripts/semantic-diff-summary.sh /tmp/templates-regression.log >> "$GITHUB_STEP_SUMMARY" || true
       - name: Test Core
         working-directory: packages/core
         run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -6720,6 +6720,7 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@formepdf/fonts-standard": "0.18.0",
+        "@formepdf/html": "^0.18.0",
         "@formepdf/templates": "0.18.0",
         "@pdf-testkit/vitest": "^0.1.5",
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,9 +1855,9 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-yZU635Tiq1p/knP55jtRDQCDgbDEHHUi1hBtAmB93Saki7vGSU67LcLlJccQmhf3Jq5F5wpyMMPiOtxxQq1stw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.5.tgz",
+      "integrity": "sha512-C1wUtpAJ2cC7syurZ+bq38YGWht3PHFI1HG/PKmH18DHi12J2lYn4czXD03aSJOqORYMZxHZ049JGQrthcK75g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1870,24 +1870,24 @@
       }
     },
     "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.1.1.tgz",
-      "integrity": "sha512-CDAVskx59I80eYOSKvf/s3a0eAdnJVE2f+/OoGSlCFA0ip3YQri72+jcwyuI9LwfuxIwu1ruiJYrjMhq8OvfCw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.1.5.tgz",
+      "integrity": "sha512-qfU/7AvhtouzawG9Ue+anfxUSxDj1PpRf28mJa3MWDOA272+VgFt5EJOcNWFfXdPClrlXOspGk1IwsnCXVLuYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.1.1"
+        "@pdf-testkit/core": "^0.1.5"
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.1.1.tgz",
-      "integrity": "sha512-74qO5J9rN5SiHPRVnyuNLCUk/+K974sL/R+MMoDZVJh+tRI5ibBnpm7OYC7yiAE/04JTrWhbbI+XoXTJdpLCBA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.1.5.tgz",
+      "integrity": "sha512-GdYYC02dRFfAmwW6pRbV3/9la6kwYgKnk54RcKpkrzfsvSeEz7DuQBppd/xxPK1KI9vTJUvO8nGx58ltlk0eJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.1.1",
-        "@pdf-testkit/matcher-core": "^0.1.1"
+        "@pdf-testkit/core": "^0.1.5",
+        "@pdf-testkit/matcher-core": "^0.1.5"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -6721,7 +6721,7 @@
         "@cloudflare/vitest-pool-workers": "^0.22.0",
         "@formepdf/fonts-standard": "0.18.0",
         "@formepdf/templates": "0.18.0",
-        "@pdf-testkit/vitest": "^0.1.1",
+        "@pdf-testkit/vitest": "^0.1.5",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.18.0",
+    "@formepdf/html": "^0.18.0",
     "@pdf-testkit/vitest": "^0.1.5",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.18.0",
-    "@pdf-testkit/vitest": "^0.1.1",
+    "@pdf-testkit/vitest": "^0.1.5",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/core/scripts/semantic-diff-summary.sh
+++ b/packages/core/scripts/semantic-diff-summary.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Dogfood experiment (non-gating): when the template-regression suite
+# fails, pull the pdf-testkit semantic diff blocks out of its captured
+# output so they land in the GitHub job summary instead of dying in the
+# log scrollback. The vitest matcher already computes and formats these;
+# this script only surfaces them. It must never fail a build: any
+# problem here prints nothing and exits 0. Remove the experiment by
+# deleting this file and the two CI lines that reference it.
+set +e
+LOG="${1:-/tmp/templates-regression.log}"
+[ -f "$LOG" ] || exit 0
+grep -q "PDF snapshot changed" "$LOG" || exit 0
+
+echo "## Template regression: semantic diff (pdf-testkit)"
+echo ""
+echo "The gate above is authoritative; this explains what moved."
+echo ""
+awk '
+  / FAIL .*regression/ { name=$0; sub(/^.*> /, "", name); next }
+  /PDF snapshot changed/ {
+    inblock=1
+    if (name != "") { print "### " name; name="" }
+    print "```"
+    sub(/^.*PDF snapshot changed/, "PDF snapshot changed")
+    print
+    next
+  }
+  inblock && /baseline: / { print; print "```"; print ""; inblock=0; next }
+  inblock { print }
+' "$LOG"
+exit 0

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-dashed-borders.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-dashed-borders.json
@@ -1,0 +1,228 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.796Z",
+  "pageCount": 1,
+  "pages": [
+    {
+      "index": 0,
+      "width": 240,
+      "height": 225,
+      "contentBox": {
+        "x": 9,
+        "y": 9,
+        "width": 222,
+        "height": 207
+      },
+      "nodeIds": [
+        "0:container:0",
+        "0:container:1",
+        "0:container:2",
+        "0:container:3",
+        "0:table:0",
+        "0:row:0",
+        "0:cell:0",
+        "0:cell:1"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 9,
+        "width": 222,
+        "height": 154.8
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 9,
+        "width": 195,
+        "height": 33
+      },
+      "order": 1,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:2",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 51,
+        "width": 195,
+        "height": 33
+      },
+      "order": 2,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:3",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 93,
+        "width": 195,
+        "height": 33
+      },
+      "order": 3,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:table:0",
+      "role": "table",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 135,
+        "width": 222,
+        "height": 28.8
+      },
+      "order": 4,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 1,
+        "cols": 2
+      }
+    },
+    {
+      "id": "0:row:0",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 135,
+        "width": 105,
+        "height": 28.8
+      },
+      "order": 5,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:0",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 9,
+        "y": 135,
+        "width": 52.5,
+        "height": 28.8
+      },
+      "order": 6,
+      "parentId": "0:row:0",
+      "text": "A",
+      "normText": "a",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:1",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 61.5,
+        "y": 135,
+        "width": 52.5,
+        "height": 28.8
+      },
+      "order": 7,
+      "parentId": "0:row:0",
+      "text": "B",
+      "normText": "b",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:0bc9f7beda495cf2fb83c854fc532ea82222a801f98c545f606e24a9dc969ea6"
+}

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-invoice.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-invoice.json
@@ -1,0 +1,1528 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.693Z",
+  "pageCount": 1,
+  "pages": [
+    {
+      "index": 0,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 54,
+        "width": 487.3,
+        "height": 733.9
+      },
+      "nodeIds": [
+        "0:container:0",
+        "0:container:1",
+        "0:image:0",
+        "0:container:2",
+        "0:text:0",
+        "0:heading:0",
+        "0:text:1",
+        "0:text:2",
+        "0:table:0",
+        "0:row:0",
+        "0:cell:0",
+        "0:cell:1",
+        "0:cell:2",
+        "0:cell:3",
+        "0:row:1",
+        "0:cell:4",
+        "0:cell:5",
+        "0:cell:6",
+        "0:cell:7",
+        "0:row:2",
+        "0:cell:8",
+        "0:cell:9",
+        "0:cell:10",
+        "0:cell:11",
+        "0:row:3",
+        "0:cell:12",
+        "0:cell:13",
+        "0:cell:14",
+        "0:cell:15",
+        "0:row:4",
+        "0:cell:16",
+        "0:cell:17",
+        "0:cell:18",
+        "0:cell:19",
+        "0:row:5",
+        "0:cell:20",
+        "0:cell:21",
+        "0:cell:22",
+        "0:cell:23",
+        "0:row:6",
+        "0:cell:24",
+        "0:cell:25",
+        "0:cell:26",
+        "0:cell:27",
+        "0:row:7",
+        "0:cell:28",
+        "0:cell:29",
+        "0:cell:30",
+        "0:heading:1",
+        "0:container:3",
+        "0:container:4",
+        "0:text:3",
+        "0:text:4",
+        "0:container:5",
+        "0:text:5",
+        "0:text:6",
+        "0:container:6",
+        "0:text:7",
+        "0:text:8",
+        "0:text:9"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 60,
+        "width": 475.3,
+        "height": 509.6
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 60,
+        "width": 475.3,
+        "height": 50.4
+      },
+      "order": 1,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:image:0",
+      "role": "image",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 60,
+        "width": 36,
+        "height": 36
+      },
+      "order": 2,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:2",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 326.5,
+        "y": 60,
+        "width": 208.7,
+        "height": 50.4
+      },
+      "order": 3,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:0",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 326.5,
+        "y": 60,
+        "width": 208.7,
+        "height": 50.4
+      },
+      "order": 4,
+      "parentId": "0:container:2",
+      "text": "Acme Widget Co. 123 Main St Springfield, IL 62704",
+      "normText": "acme widget co. 123 main st springfield, il 62704",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:heading:0",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 126.5,
+        "width": 475.3,
+        "height": 33.6
+      },
+      "order": 5,
+      "parentId": "0:container:0",
+      "text": "Invoice #2024-001",
+      "normText": "invoice #2024-001",
+      "font": {
+        "size": 24,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 1,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:1",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 176.2,
+        "width": 475.3,
+        "height": 16.8
+      },
+      "order": 6,
+      "parentId": "0:container:0",
+      "text": "Billed to Wayne Enterprises on August 28, 2026.",
+      "normText": "billed to wayne enterprises on august 28, 2026.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:2",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 205,
+        "width": 475.3,
+        "height": 16.8
+      },
+      "order": 7,
+      "parentId": "0:container:0",
+      "text": "Due net 30 days.",
+      "normText": "due net 30 days.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:table:0",
+      "role": "table",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 233.8,
+        "width": 475.3,
+        "height": 207.9
+      },
+      "order": 8,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 8,
+        "cols": 4
+      }
+    },
+    {
+      "id": "0:row:0",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 234.5,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 9,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:0",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 234.5,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 10,
+      "parentId": "0:row:0",
+      "text": "Description",
+      "normText": "description",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:1",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 234.5,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 11,
+      "parentId": "0:row:0",
+      "text": "Qty",
+      "normText": "qty",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:2",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 234.5,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 12,
+      "parentId": "0:row:0",
+      "text": "Unit",
+      "normText": "unit",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:3",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 234.5,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 13,
+      "parentId": "0:row:0",
+      "text": "Amount",
+      "normText": "amount",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:1",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 260.3,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 14,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:4",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 260.3,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 15,
+      "parentId": "0:row:1",
+      "text": "Widget Pro",
+      "normText": "widget pro",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:5",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 260.3,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 16,
+      "parentId": "0:row:1",
+      "text": "2",
+      "normText": "2",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:6",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 260.3,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 17,
+      "parentId": "0:row:1",
+      "text": "$49.00",
+      "normText": "$49.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:7",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 260.3,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 18,
+      "parentId": "0:row:1",
+      "text": "$98.00",
+      "normText": "$98.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:2",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 286.1,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 19,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:8",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 286.1,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 20,
+      "parentId": "0:row:2",
+      "text": "Widget Enterprise",
+      "normText": "widget enterprise",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:9",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 286.1,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 21,
+      "parentId": "0:row:2",
+      "text": "1",
+      "normText": "1",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:10",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 286.1,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 22,
+      "parentId": "0:row:2",
+      "text": "$199.00",
+      "normText": "$199.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:11",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 286.1,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 23,
+      "parentId": "0:row:2",
+      "text": "$199.00",
+      "normText": "$199.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:3",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 311.9,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 24,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:12",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 311.9,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 25,
+      "parentId": "0:row:3",
+      "text": "Mounting bracket",
+      "normText": "mounting bracket",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:13",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 311.9,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 26,
+      "parentId": "0:row:3",
+      "text": "4",
+      "normText": "4",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:14",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 311.9,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 27,
+      "parentId": "0:row:3",
+      "text": "$12.50",
+      "normText": "$12.50",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:15",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 311.9,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 28,
+      "parentId": "0:row:3",
+      "text": "$50.00",
+      "normText": "$50.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:4",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 337.7,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 29,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:16",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 337.7,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 30,
+      "parentId": "0:row:4",
+      "text": "Installation service",
+      "normText": "installation service",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:17",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 337.7,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 31,
+      "parentId": "0:row:4",
+      "text": "3",
+      "normText": "3",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:18",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 337.7,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 32,
+      "parentId": "0:row:4",
+      "text": "$85.00",
+      "normText": "$85.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:19",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 337.7,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 33,
+      "parentId": "0:row:4",
+      "text": "$255.00",
+      "normText": "$255.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:5",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 363.5,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 34,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:20",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 363.5,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 35,
+      "parentId": "0:row:5",
+      "text": "Extended warranty (2yr)",
+      "normText": "extended warranty (2yr)",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:21",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 363.5,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 36,
+      "parentId": "0:row:5",
+      "text": "1",
+      "normText": "1",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:22",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 363.5,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 37,
+      "parentId": "0:row:5",
+      "text": "$79.00",
+      "normText": "$79.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:23",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 363.5,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 38,
+      "parentId": "0:row:5",
+      "text": "$79.00",
+      "normText": "$79.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:6",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 389.3,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 39,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:24",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 389.3,
+        "width": 236.9,
+        "height": 25.8
+      },
+      "order": 40,
+      "parentId": "0:row:6",
+      "text": "Shipping & handling",
+      "normText": "shipping & handling",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:25",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 297.6,
+        "y": 389.3,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 41,
+      "parentId": "0:row:6",
+      "text": "1",
+      "normText": "1",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:26",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 389.3,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 42,
+      "parentId": "0:row:6",
+      "text": "$24.00",
+      "normText": "$24.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:27",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 389.3,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 43,
+      "parentId": "0:row:6",
+      "text": "$24.00",
+      "normText": "$24.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:7",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 415.1,
+        "width": 473.8,
+        "height": 25.8
+      },
+      "order": 44,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:28",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60.8,
+        "y": 415.1,
+        "width": 308,
+        "height": 25.8
+      },
+      "order": 45,
+      "parentId": "0:row:7",
+      "text": "Total",
+      "normText": "total",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:29",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 368.7,
+        "y": 415.1,
+        "width": 71.1,
+        "height": 25.8
+      },
+      "order": 46,
+      "parentId": "0:row:7",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:30",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 439.8,
+        "y": 415.1,
+        "width": 94.8,
+        "height": 25.8
+      },
+      "order": 47,
+      "parentId": "0:row:7",
+      "text": "$705.00",
+      "normText": "$705.00",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:heading:1",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 456.6,
+        "width": 475.3,
+        "height": 25.2
+      },
+      "order": 48,
+      "parentId": "0:container:0",
+      "text": "Payment terms",
+      "normText": "payment terms",
+      "font": {
+        "size": 18,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 2,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:3",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 496.7,
+        "width": 475.3,
+        "height": 50.4
+      },
+      "order": 49,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:4",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 496.7,
+        "width": 445.3,
+        "height": 16.8
+      },
+      "order": 50,
+      "parentId": "0:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:3",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 496.7,
+        "width": 13.2,
+        "height": 16.8
+      },
+      "order": 51,
+      "parentId": "0:container:4",
+      "text": "•",
+      "normText": "•",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:4",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 103.2,
+        "y": 496.7,
+        "width": 432.1,
+        "height": 16.8
+      },
+      "order": 52,
+      "parentId": "0:container:4",
+      "text": "Payment due within 30 days of invoice date.",
+      "normText": "payment due within 30 days of invoice date.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:5",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 513.5,
+        "width": 445.3,
+        "height": 16.8
+      },
+      "order": 53,
+      "parentId": "0:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:5",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 513.5,
+        "width": 13.2,
+        "height": 16.8
+      },
+      "order": 54,
+      "parentId": "0:container:5",
+      "text": "•",
+      "normText": "•",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:6",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 103.2,
+        "y": 513.5,
+        "width": 432.1,
+        "height": 16.8
+      },
+      "order": 55,
+      "parentId": "0:container:5",
+      "text": "Make checks payable to Acme Widget Co.",
+      "normText": "make checks payable to acme widget co.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:6",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 530.3,
+        "width": 445.3,
+        "height": 16.8
+      },
+      "order": 56,
+      "parentId": "0:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:7",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 90,
+        "y": 530.3,
+        "width": 13.2,
+        "height": 16.8
+      },
+      "order": 57,
+      "parentId": "0:container:6",
+      "text": "•",
+      "normText": "•",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:8",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 103.2,
+        "y": 530.3,
+        "width": 432.1,
+        "height": 16.8
+      },
+      "order": 58,
+      "parentId": "0:container:6",
+      "text": "A 1.5% monthly finance charge applies to late balances.",
+      "normText": "a 1.5% monthly finance charge applies to late balances.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:9",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 559.1,
+        "width": 475.3,
+        "height": 10.5
+      },
+      "order": 59,
+      "parentId": "0:container:0",
+      "text": "Thank you for your business!",
+      "normText": "thank you for your business!",
+      "font": {
+        "size": 7.5,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:8b8e36f5efd11fd06ada4558ed1f0113ccd076857eef01fb3e9c117152baa3bb"
+}

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-letterhead.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-letterhead.json
@@ -1,0 +1,1125 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.716Z",
+  "pageCount": 3,
+  "pages": [
+    {
+      "index": 0,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 72,
+        "width": 487.3,
+        "height": 769.9
+      },
+      "nodeIds": [
+        "0:text:0",
+        "0:heading:0",
+        "0:text:1",
+        "0:container:0",
+        "0:container:1",
+        "0:container:2",
+        "0:container:3",
+        "0:container:4",
+        "0:container:5",
+        "0:text:2"
+      ]
+    },
+    {
+      "index": 1,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 841.9
+      },
+      "nodeIds": [
+        "1:container:0",
+        "1:container:1",
+        "1:container:2",
+        "1:container:3",
+        "1:container:4",
+        "1:text:0",
+        "1:container:5",
+        "1:heading:0",
+        "1:text:1",
+        "1:container:6",
+        "1:container:7",
+        "1:container:8",
+        "1:container:9",
+        "1:container:10",
+        "1:container:11",
+        "1:text:2"
+      ]
+    },
+    {
+      "index": 2,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 841.9
+      },
+      "nodeIds": [
+        "2:container:0",
+        "2:container:1",
+        "2:container:2",
+        "2:container:3",
+        "2:container:4",
+        "2:text:0",
+        "2:container:5",
+        "2:heading:0",
+        "2:container:6",
+        "2:text:1",
+        "2:container:7",
+        "2:container:8",
+        "2:container:9",
+        "2:container:10",
+        "2:container:11",
+        "2:container:12",
+        "2:text:2"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:text:0",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 81,
+        "width": 475.3,
+        "height": 12.6
+      },
+      "order": 0,
+      "parentId": null,
+      "text": "INTERNAL — ÉDITION RÉSERVÉE",
+      "normText": "internal — édition réservée",
+      "font": {
+        "size": 9,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:heading:0",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 293.6,
+        "width": 475.3,
+        "height": 33.6
+      },
+      "order": 1,
+      "parentId": null,
+      "text": "2026 Strategy Memo",
+      "normText": "2026 strategy memo",
+      "font": {
+        "size": 24,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 1,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:1",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 343.3,
+        "width": 475.3,
+        "height": 16.8
+      },
+      "order": 2,
+      "parentId": null,
+      "text": "Prepared for the board — do not distribute.",
+      "normText": "prepared for the board — do not distribute.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 3,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 4,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:2",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 487.3,
+        "height": 16.8
+      },
+      "order": 5,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:3",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 6,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:4",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 216.4,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 7,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:5",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 8,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:2",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 9,
+      "parentId": "0:container:5",
+      "text": "\u0002",
+      "normText": "\u0002",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:0",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:1",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 1,
+      "parentId": "1:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:2",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 29.7,
+        "width": 487.3,
+        "height": 12.6
+      },
+      "order": 2,
+      "parentId": "1:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:3",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 3,
+      "parentId": "1:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:4",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 216.4,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 4,
+      "parentId": "1:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:0",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 216.4,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 5,
+      "parentId": "1:container:4",
+      "text": "ACME WIDGET CO. — CONFIDENTIAL",
+      "normText": "acme widget co. — confidential",
+      "font": {
+        "size": 9,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:5",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 378.9,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 6,
+      "parentId": "1:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:heading:0",
+      "role": "heading",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 72,
+        "width": 475.3,
+        "height": 25.2
+      },
+      "order": 7,
+      "parentId": null,
+      "text": "Background",
+      "normText": "background",
+      "font": {
+        "size": 18,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 2,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:1",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 112.1,
+        "width": 475.3,
+        "height": 16.8
+      },
+      "order": 8,
+      "parentId": null,
+      "text": "Body content on an inner page, beneath the running letterhead.",
+      "normText": "body content on an inner page, beneath the running letterhead.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:6",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 9,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:7",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 10,
+      "parentId": "1:container:6",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:8",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 487.3,
+        "height": 16.8
+      },
+      "order": 11,
+      "parentId": "1:container:7",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:9",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 12,
+      "parentId": "1:container:8",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:10",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 216.4,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 13,
+      "parentId": "1:container:8",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:11",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 14,
+      "parentId": "1:container:8",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:2",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 15,
+      "parentId": "1:container:11",
+      "text": "\u0002",
+      "normText": "\u0002",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:0",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:1",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 0,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 1,
+      "parentId": "2:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:2",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 29.7,
+        "width": 487.3,
+        "height": 12.6
+      },
+      "order": 2,
+      "parentId": "2:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:3",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 3,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:4",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 216.4,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 4,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:text:0",
+      "role": "text",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 216.4,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 5,
+      "parentId": "2:container:4",
+      "text": "ACME WIDGET CO. — CONFIDENTIAL",
+      "normText": "acme widget co. — confidential",
+      "font": {
+        "size": 9,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:5",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 378.9,
+        "y": 29.7,
+        "width": 162.4,
+        "height": 12.6
+      },
+      "order": 6,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:heading:0",
+      "role": "heading",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 72,
+        "width": 475.3,
+        "height": 25.2
+      },
+      "order": 7,
+      "parentId": "2:container:6",
+      "text": "Recommendation",
+      "normText": "recommendation",
+      "font": {
+        "size": 18,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 2,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:6",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 81,
+        "width": 475.3,
+        "height": 566.8
+      },
+      "order": 8,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:text:1",
+      "role": "text",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 112.1,
+        "width": 475.3,
+        "height": 16.8
+      },
+      "order": 9,
+      "parentId": "2:container:6",
+      "text": "More inner-page content, same letterhead.",
+      "normText": "more inner-page content, same letterhead.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:7",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 10,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:8",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 769.9,
+        "width": 487.3,
+        "height": 72
+      },
+      "order": 11,
+      "parentId": "2:container:7",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:9",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 487.3,
+        "height": 16.8
+      },
+      "order": 12,
+      "parentId": "2:container:8",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:10",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 54,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 13,
+      "parentId": "2:container:9",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:11",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 216.4,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 14,
+      "parentId": "2:container:9",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:12",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 15,
+      "parentId": "2:container:9",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:text:2",
+      "role": "text",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 378.9,
+        "y": 797.5,
+        "width": 162.4,
+        "height": 16.8
+      },
+      "order": 16,
+      "parentId": "2:container:12",
+      "text": "\u0002",
+      "normText": "\u0002",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:0c9c62bc8e5c73c00317efeb48292e5bb9554d6a1810670720d8d011fb0d744f"
+}

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-report.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-report.json
@@ -1,0 +1,1567 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.738Z",
+  "pageCount": 4,
+  "pages": [
+    {
+      "index": 0,
+      "width": 612,
+      "height": 792,
+      "contentBox": {
+        "x": 60,
+        "y": 120,
+        "width": 492,
+        "height": 672
+      },
+      "nodeIds": [
+        "0:heading:0",
+        "0:text:0",
+        "0:container:0",
+        "0:container:1",
+        "0:container:2",
+        "0:container:3",
+        "0:container:4",
+        "0:text:1",
+        "0:container:5"
+      ]
+    },
+    {
+      "index": 1,
+      "width": 612,
+      "height": 792,
+      "contentBox": {
+        "x": 60,
+        "y": 72,
+        "width": 492,
+        "height": 720
+      },
+      "nodeIds": [
+        "1:heading:0",
+        "1:text:0",
+        "1:text:1",
+        "1:text:2",
+        "1:container:0",
+        "1:text:3",
+        "1:container:1",
+        "1:container:2",
+        "1:container:3",
+        "1:container:4",
+        "1:container:5",
+        "1:text:4",
+        "1:container:6"
+      ]
+    },
+    {
+      "index": 2,
+      "width": 612,
+      "height": 792,
+      "contentBox": {
+        "x": 60,
+        "y": 72,
+        "width": 492,
+        "height": 720
+      },
+      "nodeIds": [
+        "2:table:0",
+        "2:row:0",
+        "2:cell:0",
+        "2:cell:1",
+        "2:row:1",
+        "2:cell:2",
+        "2:cell:3",
+        "2:row:2",
+        "2:cell:4",
+        "2:cell:5",
+        "2:row:3",
+        "2:cell:6",
+        "2:cell:7",
+        "2:row:4",
+        "2:cell:8",
+        "2:cell:9",
+        "2:row:5",
+        "2:cell:10",
+        "2:cell:11",
+        "2:row:6",
+        "2:cell:12",
+        "2:cell:13",
+        "2:container:0",
+        "2:container:1",
+        "2:container:2",
+        "2:container:3",
+        "2:container:4",
+        "2:text:0",
+        "2:container:5"
+      ]
+    },
+    {
+      "index": 3,
+      "width": 612,
+      "height": 792,
+      "contentBox": {
+        "x": 60,
+        "y": 72,
+        "width": 492,
+        "height": 720
+      },
+      "nodeIds": [
+        "3:heading:0",
+        "3:text:0",
+        "3:container:0",
+        "3:container:1",
+        "3:container:2",
+        "3:container:3",
+        "3:container:4",
+        "3:text:1",
+        "3:container:5"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:heading:0",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 66,
+        "y": 134.7,
+        "width": 480,
+        "height": 30.8
+      },
+      "order": 0,
+      "parentId": null,
+      "text": "Quarterly Report",
+      "normText": "quarterly report",
+      "font": {
+        "size": 22,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 1,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:0",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 66,
+        "y": 180.3,
+        "width": 480,
+        "height": 33.6
+      },
+      "order": 1,
+      "parentId": null,
+      "text": "Executive summary: revenue grew for the third consecutive quarter. The sections that follow each start on their own page.",
+      "normText": "executive summary: revenue grew for the third consecutive quarter. the sections that follow each start on their own page.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 2,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 3,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:2",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 492,
+        "height": 16.8
+      },
+      "order": 4,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:3",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 5,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:4",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 6,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:1",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 7,
+      "parentId": "0:container:4",
+      "text": "Page \u0002 of \u0003",
+      "normText": "page \u0002 of \u0003",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:5",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 388,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 8,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:heading:0",
+      "role": "heading",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 72,
+        "width": 480,
+        "height": 22.4
+      },
+      "order": 0,
+      "parentId": null,
+      "text": "Section One — Filler",
+      "normText": "section one — filler",
+      "font": {
+        "size": 16,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 2,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:0",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 107.7,
+        "width": 480,
+        "height": 16.8
+      },
+      "order": 1,
+      "parentId": null,
+      "text": "Paragraph one of the filler block, present to give the page some body.",
+      "normText": "paragraph one of the filler block, present to give the page some body.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:1",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 136.5,
+        "width": 480,
+        "height": 16.8
+      },
+      "order": 2,
+      "parentId": null,
+      "text": "Paragraph two of the filler block, present to give the page some body.",
+      "normText": "paragraph two of the filler block, present to give the page some body.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:2",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 165.3,
+        "width": 480,
+        "height": 16.8
+      },
+      "order": 3,
+      "parentId": null,
+      "text": "Paragraph three of the filler block, present to give the page some body.",
+      "normText": "paragraph three of the filler block, present to give the page some body.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:0",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 194.1,
+        "width": 480,
+        "height": 430
+      },
+      "order": 4,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:3",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 66,
+        "y": 636.1,
+        "width": 480,
+        "height": 16.8
+      },
+      "order": 5,
+      "parentId": null,
+      "text": "Final paragraph, pushing the table close to the page bottom.",
+      "normText": "final paragraph, pushing the table close to the page bottom.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:1",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 6,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:2",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 7,
+      "parentId": "1:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:3",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 492,
+        "height": 16.8
+      },
+      "order": 8,
+      "parentId": "1:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:4",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 9,
+      "parentId": "1:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:5",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 10,
+      "parentId": "1:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:text:4",
+      "role": "text",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 11,
+      "parentId": "1:container:5",
+      "text": "Page \u0002 of \u0003",
+      "normText": "page \u0002 of \u0003",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "1:container:6",
+      "role": "container",
+      "pageIndex": 1,
+      "bbox": {
+        "x": 388,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 12,
+      "parentId": "1:container:3",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:table:0",
+      "role": "table",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 72,
+        "width": 480,
+        "height": 159.6
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 7,
+        "cols": 2
+      }
+    },
+    {
+      "id": "2:row:0",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 72,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 1,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:0",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 72,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 2,
+      "parentId": "2:row:0",
+      "text": "Region",
+      "normText": "region",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:1",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 72,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 3,
+      "parentId": "2:row:0",
+      "text": "Q3",
+      "normText": "q3",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:1",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 94.8,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 4,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:2",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 94.8,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 5,
+      "parentId": "2:row:1",
+      "text": "North",
+      "normText": "north",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:3",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 94.8,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 6,
+      "parentId": "2:row:1",
+      "text": "$412k",
+      "normText": "$412k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:2",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 117.6,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 7,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:4",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 117.6,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 8,
+      "parentId": "2:row:2",
+      "text": "South",
+      "normText": "south",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:5",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 117.6,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 9,
+      "parentId": "2:row:2",
+      "text": "$388k",
+      "normText": "$388k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:3",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 140.4,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 10,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:6",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 140.4,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 11,
+      "parentId": "2:row:3",
+      "text": "East",
+      "normText": "east",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:7",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 140.4,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 12,
+      "parentId": "2:row:3",
+      "text": "$293k",
+      "normText": "$293k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:4",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 163.2,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 13,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:8",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 163.2,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 14,
+      "parentId": "2:row:4",
+      "text": "West",
+      "normText": "west",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:9",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 163.2,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 15,
+      "parentId": "2:row:4",
+      "text": "$305k",
+      "normText": "$305k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:5",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 186,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 16,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:10",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 186,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 17,
+      "parentId": "2:row:5",
+      "text": "Central",
+      "normText": "central",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:11",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 186,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 18,
+      "parentId": "2:row:5",
+      "text": "$251k",
+      "normText": "$251k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:row:6",
+      "role": "row",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 208.8,
+        "width": 480,
+        "height": 22.8
+      },
+      "order": 19,
+      "parentId": "2:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:12",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 66,
+        "y": 208.8,
+        "width": 265.3,
+        "height": 22.8
+      },
+      "order": 20,
+      "parentId": "2:row:6",
+      "text": "Offshore",
+      "normText": "offshore",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:cell:13",
+      "role": "cell",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 331.3,
+        "y": 208.8,
+        "width": 214.7,
+        "height": 22.8
+      },
+      "order": 21,
+      "parentId": "2:row:6",
+      "text": "$140k",
+      "normText": "$140k",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:0",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 22,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:1",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 23,
+      "parentId": "2:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:2",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 492,
+        "height": 16.8
+      },
+      "order": 24,
+      "parentId": "2:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:3",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 25,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:4",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 26,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:text:0",
+      "role": "text",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 27,
+      "parentId": "2:container:4",
+      "text": "Page \u0002 of \u0003",
+      "normText": "page \u0002 of \u0003",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "2:container:5",
+      "role": "container",
+      "pageIndex": 2,
+      "bbox": {
+        "x": 388,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 28,
+      "parentId": "2:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:heading:0",
+      "role": "heading",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 66,
+        "y": 72,
+        "width": 480,
+        "height": 25.2
+      },
+      "order": 0,
+      "parentId": null,
+      "text": "Section Two — Legacy Alias",
+      "normText": "section two — legacy alias",
+      "font": {
+        "size": 18,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 2,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:text:0",
+      "role": "text",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 66,
+        "y": 112.1,
+        "width": 480,
+        "height": 33.6
+      },
+      "order": 1,
+      "parentId": null,
+      "text": "This section used page-break-before: always, the pre-2018 spelling every wkhtmltopdf template still carries.",
+      "normText": "this section used page-break-before: always, the pre-2018 spelling every wkhtmltopdf template still carries.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:0",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 2,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:1",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 60,
+        "y": 720,
+        "width": 492,
+        "height": 72
+      },
+      "order": 3,
+      "parentId": "3:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:2",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 492,
+        "height": 16.8
+      },
+      "order": 4,
+      "parentId": "3:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:3",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 60,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 5,
+      "parentId": "3:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:4",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 6,
+      "parentId": "3:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:text:1",
+      "role": "text",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 224,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 7,
+      "parentId": "3:container:4",
+      "text": "Page \u0002 of \u0003",
+      "normText": "page \u0002 of \u0003",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "3:container:5",
+      "role": "container",
+      "pageIndex": 3,
+      "bbox": {
+        "x": 388,
+        "y": 747.6,
+        "width": 164,
+        "height": 16.8
+      },
+      "order": 8,
+      "parentId": "3:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:a1cef8407a31eeb2ed6b25f61bb79e1f02d6fd4660190c857741f963ebda01bc"
+}

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-statement.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-statement.json
@@ -1,0 +1,828 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.758Z",
+  "pageCount": 1,
+  "pages": [
+    {
+      "index": 0,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 54,
+        "width": 487.3,
+        "height": 733.9
+      },
+      "nodeIds": [
+        "0:container:0",
+        "0:container:1",
+        "0:heading:0",
+        "0:text:0",
+        "0:table:0",
+        "0:row:0",
+        "0:cell:0",
+        "0:cell:1",
+        "0:cell:2",
+        "0:row:1",
+        "0:cell:3",
+        "0:cell:4",
+        "0:cell:5",
+        "0:row:2",
+        "0:cell:6",
+        "0:cell:7",
+        "0:cell:8",
+        "0:row:3",
+        "0:cell:9",
+        "0:cell:10",
+        "0:row:4",
+        "0:cell:11",
+        "0:cell:12",
+        "0:cell:13",
+        "0:text:1",
+        "0:text:2",
+        "0:text:3",
+        "0:text:4",
+        "0:container:2",
+        "0:container:3",
+        "0:text:5",
+        "0:text:6"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 67.4,
+        "width": 475.3,
+        "height": 374.1
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 67.4,
+        "width": 420,
+        "height": 374.1
+      },
+      "order": 1,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:heading:0",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 67.4,
+        "width": 420,
+        "height": 28
+      },
+      "order": 2,
+      "parentId": "0:container:1",
+      "text": "Account Statement",
+      "normText": "account statement",
+      "font": {
+        "size": 20,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 1,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:0",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 108.8,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 3,
+      "parentId": "0:container:1",
+      "text": "Statement period: August 1–28, 2026",
+      "normText": "statement period: august 1–28, 2026",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:table:0",
+      "role": "table",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 137.6,
+        "width": 420,
+        "height": 159.9
+      },
+      "order": 4,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 5,
+        "cols": 3
+      }
+    },
+    {
+      "id": "0:row:0",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 137.6,
+        "width": 420,
+        "height": 18.3
+      },
+      "order": 5,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:0",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 137.6,
+        "width": 99.6,
+        "height": 18.3
+      },
+      "order": 6,
+      "parentId": "0:row:0",
+      "text": "Date",
+      "normText": "date",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:1",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 187.2,
+        "y": 137.6,
+        "width": 228.4,
+        "height": 18.3
+      },
+      "order": 7,
+      "parentId": "0:row:0",
+      "text": "Description",
+      "normText": "description",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:2",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 415.6,
+        "y": 137.6,
+        "width": 92,
+        "height": 18.3
+      },
+      "order": 8,
+      "parentId": "0:row:0",
+      "text": "Amount",
+      "normText": "amount",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:1",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 155.9,
+        "width": 420,
+        "height": 22.8
+      },
+      "order": 9,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:3",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 155.9,
+        "width": 99.6,
+        "height": 22.8
+      },
+      "order": 10,
+      "parentId": "0:row:1",
+      "text": "Aug 03",
+      "normText": "aug 03",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:4",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 187.2,
+        "y": 155.9,
+        "width": 228.4,
+        "height": 22.8
+      },
+      "order": 11,
+      "parentId": "0:row:1",
+      "text": "Widget Pro subscription",
+      "normText": "widget pro subscription",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:5",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 415.6,
+        "y": 155.9,
+        "width": 92,
+        "height": 22.8
+      },
+      "order": 12,
+      "parentId": "0:row:1",
+      "text": "$49.00",
+      "normText": "$49.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:2",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 178.7,
+        "width": 420,
+        "height": 22.8
+      },
+      "order": 13,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:6",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 178.7,
+        "width": 99.6,
+        "height": 22.8
+      },
+      "order": 14,
+      "parentId": "0:row:2",
+      "text": "Aug 17",
+      "normText": "aug 17",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:7",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 187.2,
+        "y": 178.7,
+        "width": 228.4,
+        "height": 22.8
+      },
+      "order": 15,
+      "parentId": "0:row:2",
+      "text": "Support plan",
+      "normText": "support plan",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:8",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 415.6,
+        "y": 178.7,
+        "width": 92,
+        "height": 22.8
+      },
+      "order": 16,
+      "parentId": "0:row:2",
+      "text": "$25.00",
+      "normText": "$25.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:3",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 201.5,
+        "width": 420,
+        "height": 56.4
+      },
+      "order": 17,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:9",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 201.5,
+        "width": 328,
+        "height": 56.4
+      },
+      "order": 18,
+      "parentId": "0:row:3",
+      "text": "Total for the period including all fees and adjustments",
+      "normText": "total for the period including all fees and adjustments",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:10",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 415.6,
+        "y": 201.5,
+        "width": 92,
+        "height": 56.4
+      },
+      "order": 19,
+      "parentId": "0:row:3",
+      "text": "$74.00",
+      "normText": "$74.00",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:4",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 257.9,
+        "width": 420,
+        "height": 39.6
+      },
+      "order": 20,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:11",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 257.9,
+        "width": 99.6,
+        "height": 39.6
+      },
+      "order": 21,
+      "parentId": "0:row:4",
+      "text": "Carried forward",
+      "normText": "carried forward",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:12",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 187.2,
+        "y": 257.9,
+        "width": 228.4,
+        "height": 39.6
+      },
+      "order": 22,
+      "parentId": "0:row:4",
+      "text": "legacy valign attr",
+      "normText": "legacy valign attr",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:13",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 415.6,
+        "y": 257.9,
+        "width": 92,
+        "height": 39.6
+      },
+      "order": 23,
+      "parentId": "0:row:4",
+      "text": "$0.00",
+      "normText": "$0.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:1",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 309.5,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 24,
+      "parentId": "0:container:1",
+      "text": "Payment overdue",
+      "normText": "payment overdue",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:2",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 338.3,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 25,
+      "parentId": "0:container:1",
+      "text": "Tie-breaker paragraph",
+      "normText": "tie-breaker paragraph",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:3",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 367.1,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 26,
+      "parentId": "0:container:1",
+      "text": "Kept selector paragraph",
+      "normText": "kept selector paragraph",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:4",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 395.9,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 27,
+      "parentId": "0:container:1",
+      "text": "Order check paragraph",
+      "normText": "order check paragraph",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:2",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 87.6,
+        "y": 424.7,
+        "width": 420,
+        "height": 16.8
+      },
+      "order": 28,
+      "parentId": "0:container:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:3",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 117.6,
+        "y": 424.7,
+        "width": 390,
+        "height": 16.8
+      },
+      "order": 29,
+      "parentId": "0:container:2",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:5",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 117.6,
+        "y": 424.7,
+        "width": 13.2,
+        "height": 16.8
+      },
+      "order": 30,
+      "parentId": "0:container:3",
+      "text": "•",
+      "normText": "•",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:6",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 130.8,
+        "y": 424.7,
+        "width": 376.8,
+        "height": 16.8
+      },
+      "order": 31,
+      "parentId": "0:container:3",
+      "text": "Autopay is enabled for this account.",
+      "normText": "autopay is enabled for this account.",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:7b6b58b524f3de42bee29d77e8762b3838c5d18e4479e3b3c00f1da28e6dfdca"
+}

--- a/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-zebra-invoice.json
+++ b/packages/core/tests/__pdf_snapshots__/html-fixtures.regression.test-html-fixture-zebra-invoice.json
@@ -1,0 +1,982 @@
+{
+  "version": 1,
+  "producer": "formepdf",
+  "createdAt": "2026-09-05T01:27:33.779Z",
+  "pageCount": 1,
+  "pages": [
+    {
+      "index": 0,
+      "width": 595.3,
+      "height": 841.9,
+      "contentBox": {
+        "x": 54,
+        "y": 54,
+        "width": 487.3,
+        "height": 733.9
+      },
+      "nodeIds": [
+        "0:container:0",
+        "0:container:1",
+        "0:text:0",
+        "0:heading:0",
+        "0:table:0",
+        "0:row:0",
+        "0:cell:0",
+        "0:cell:1",
+        "0:cell:2",
+        "0:row:1",
+        "0:cell:3",
+        "0:cell:4",
+        "0:cell:5",
+        "0:row:2",
+        "0:cell:6",
+        "0:cell:7",
+        "0:cell:8",
+        "0:row:3",
+        "0:cell:9",
+        "0:cell:10",
+        "0:cell:11",
+        "0:row:4",
+        "0:cell:12",
+        "0:cell:13",
+        "0:cell:14",
+        "0:row:5",
+        "0:cell:15",
+        "0:cell:16",
+        "0:table:1",
+        "0:row:6",
+        "0:cell:17",
+        "0:cell:18",
+        "0:row:7",
+        "0:cell:19",
+        "0:cell:20",
+        "0:row:8",
+        "0:cell:21",
+        "0:cell:22"
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "0:container:0",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 60,
+        "width": 475.3,
+        "height": 313
+      },
+      "order": 0,
+      "parentId": null,
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:1",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 452.2,
+        "y": 60,
+        "width": 77.1,
+        "height": 43.3
+      },
+      "order": 1,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 22,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:0",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 464.5,
+        "y": 66.3,
+        "width": 52.6,
+        "height": 30.8
+      },
+      "order": 2,
+      "parentId": "0:container:1",
+      "text": "PAID",
+      "normText": "paid",
+      "font": {
+        "size": 22,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:heading:0",
+      "role": "heading",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 72.1,
+        "width": 475.3,
+        "height": 25.2
+      },
+      "order": 3,
+      "parentId": "0:container:0",
+      "text": "Zebra Invoice",
+      "normText": "zebra invoice",
+      "font": {
+        "size": 18,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": 1,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:table:0",
+      "role": "table",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 109.3,
+        "width": 475.3,
+        "height": 160.1
+      },
+      "order": 4,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 6,
+        "cols": 3
+      }
+    },
+    {
+      "id": "0:row:0",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 109.3,
+        "width": 475.3,
+        "height": 27.3
+      },
+      "order": 5,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:0",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 109.3,
+        "width": 121.1,
+        "height": 27.3
+      },
+      "order": 6,
+      "parentId": "0:row:0",
+      "text": "SKU",
+      "normText": "sku",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:1",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 181.1,
+        "y": 109.3,
+        "width": 216.6,
+        "height": 27.3
+      },
+      "order": 7,
+      "parentId": "0:row:0",
+      "text": "Item",
+      "normText": "item",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:2",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 109.3,
+        "width": 137.6,
+        "height": 27.3
+      },
+      "order": 8,
+      "parentId": "0:row:0",
+      "text": "Amount",
+      "normText": "amount",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:1",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 136.6,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 9,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:3",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 136.6,
+        "width": 121.1,
+        "height": 26.6
+      },
+      "order": 10,
+      "parentId": "0:row:1",
+      "text": "W-100",
+      "normText": "w-100",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:4",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 181.1,
+        "y": 136.6,
+        "width": 216.6,
+        "height": 26.6
+      },
+      "order": 11,
+      "parentId": "0:row:1",
+      "text": "Widget Pro",
+      "normText": "widget pro",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:5",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 136.6,
+        "width": 137.6,
+        "height": 26.6
+      },
+      "order": 12,
+      "parentId": "0:row:1",
+      "text": "$98.00",
+      "normText": "$98.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:2",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 163.2,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 13,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:6",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 163.2,
+        "width": 121.1,
+        "height": 26.6
+      },
+      "order": 14,
+      "parentId": "0:row:2",
+      "text": "W-200",
+      "normText": "w-200",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:7",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 181.1,
+        "y": 163.2,
+        "width": 216.6,
+        "height": 26.6
+      },
+      "order": 15,
+      "parentId": "0:row:2",
+      "text": "Widget Enterprise",
+      "normText": "widget enterprise",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:8",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 163.2,
+        "width": 137.6,
+        "height": 26.6
+      },
+      "order": 16,
+      "parentId": "0:row:2",
+      "text": "$199.00",
+      "normText": "$199.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:3",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 189.7,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 17,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:9",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 189.7,
+        "width": 121.1,
+        "height": 26.6
+      },
+      "order": 18,
+      "parentId": "0:row:3",
+      "text": "B-050",
+      "normText": "b-050",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:10",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 181.1,
+        "y": 189.7,
+        "width": 216.6,
+        "height": 26.6
+      },
+      "order": 19,
+      "parentId": "0:row:3",
+      "text": "Mounting bracket",
+      "normText": "mounting bracket",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:11",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 189.7,
+        "width": 137.6,
+        "height": 26.6
+      },
+      "order": 20,
+      "parentId": "0:row:3",
+      "text": "$50.00",
+      "normText": "$50.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:4",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 216.3,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 21,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:12",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 216.3,
+        "width": 121.1,
+        "height": 26.6
+      },
+      "order": 22,
+      "parentId": "0:row:4",
+      "text": "S-300",
+      "normText": "s-300",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:13",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 181.1,
+        "y": 216.3,
+        "width": 216.6,
+        "height": 26.6
+      },
+      "order": 23,
+      "parentId": "0:row:4",
+      "text": "Installation service",
+      "normText": "installation service",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:14",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 216.3,
+        "width": 137.6,
+        "height": 26.6
+      },
+      "order": 24,
+      "parentId": "0:row:4",
+      "text": "$255.00",
+      "normText": "$255.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:5",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 242.8,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 25,
+      "parentId": "0:table:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:15",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 242.8,
+        "width": 337.7,
+        "height": 26.6
+      },
+      "order": 26,
+      "parentId": "0:row:5",
+      "text": "Total",
+      "normText": "total",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:16",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 397.7,
+        "y": 242.8,
+        "width": 137.6,
+        "height": 26.6
+      },
+      "order": 27,
+      "parentId": "0:row:5",
+      "text": "$602.00",
+      "normText": "$602.00",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:table:1",
+      "role": "table",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 293.4,
+        "width": 475.3,
+        "height": 79.7
+      },
+      "order": 28,
+      "parentId": "0:container:0",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1,
+      "table": {
+        "rows": 3,
+        "cols": 2
+      }
+    },
+    {
+      "id": "0:row:6",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 293.4,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 29,
+      "parentId": "0:table:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:17",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 293.4,
+        "width": 238.8,
+        "height": 26.6
+      },
+      "order": 30,
+      "parentId": "0:row:6",
+      "text": "Subtotal",
+      "normText": "subtotal",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:18",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 298.8,
+        "y": 293.4,
+        "width": 236.5,
+        "height": 26.6
+      },
+      "order": 31,
+      "parentId": "0:row:6",
+      "text": "$602.00",
+      "normText": "$602.00",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:7",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 319.9,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 32,
+      "parentId": "0:table:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:19",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 319.9,
+        "width": 238.8,
+        "height": 26.6
+      },
+      "order": 33,
+      "parentId": "0:row:7",
+      "text": "Tax (8%)",
+      "normText": "tax (8%)",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:20",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 298.8,
+        "y": 319.9,
+        "width": 236.5,
+        "height": 26.6
+      },
+      "order": 34,
+      "parentId": "0:row:7",
+      "text": "$48.16",
+      "normText": "$48.16",
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:row:8",
+      "role": "row",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 346.5,
+        "width": 475.3,
+        "height": 26.6
+      },
+      "order": 35,
+      "parentId": "0:table:1",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:21",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 60,
+        "y": 346.5,
+        "width": 238.8,
+        "height": 26.6
+      },
+      "order": 36,
+      "parentId": "0:row:8",
+      "text": "Due",
+      "normText": "due",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:cell:22",
+      "role": "cell",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 298.8,
+        "y": 346.5,
+        "width": 236.5,
+        "height": 26.6
+      },
+      "order": 37,
+      "parentId": "0:row:8",
+      "text": "$650.16",
+      "normText": "$650.16",
+      "font": {
+        "size": 12,
+        "weight": 700,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    }
+  ],
+  "contentHash": "sha256:80da48e4c178560e9fe3463185898facf67fd468ebf4edf1488538c98867380e"
+}

--- a/packages/core/tests/html-fixtures.regression.test.ts
+++ b/packages/core/tests/html-fixtures.regression.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { renderHtmlWithLayout } from '@formepdf/html';
+// Registers `toMatchPDFSnapshot` on Vitest's `expect`.
+import '@pdf-testkit/vitest';
+
+/**
+ * Structural-regression baselines for the HTML input path's fixture corpus.
+ *
+ * The dogfood experiment's sample-size finding (2026-09-05): the last weeks
+ * of layout churn happened almost entirely in the HTML path — the table
+ * auto-layout fix, the measure/layout gate fixes, the float transformation —
+ * and NONE of it was visible to pdf-testkit, because only the React-template
+ * surface had baselines. Ten times the sample was sitting here, invisible.
+ * These baselines close that: every future engine or mapper change that
+ * moves one of these fixtures now produces a semantic diff in the same CI
+ * surface as the shipped templates, instead of relying on the byte wall
+ * being run by hand.
+ *
+ * `renderHtmlWithLayout` resolves to the WORKSPACE @formepdf/html (built by
+ * the "Build HTML WASM package" CI step before this suite runs), so the
+ * layouts track the current branch's engine, not the last published WASM.
+ * Same fixture set as scripts/byte-wall.sh, same reason: these six are the
+ * float-free corpus every layout change is measured against.
+ */
+const FIXTURES = [
+  'invoice',
+  'letterhead',
+  'report',
+  'statement',
+  'zebra-invoice',
+  'dashed-borders',
+] as const;
+
+describe('html fixture regressions (the byte-wall corpus, structurally)', () => {
+  it.each(FIXTURES.map((f) => [f] as const))(
+    '%s layout matches the committed structural baseline',
+    async (name) => {
+      const html = readFileSync(
+        new URL(`../../../html/tests/fixtures/${name}.html`, import.meta.url),
+        'utf8',
+      );
+      const { layout } = renderHtmlWithLayout(html);
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: `html-fixture-${name}` });
+    },
+  );
+});

--- a/packages/core/vitest.config.templates.ts
+++ b/packages/core/vitest.config.templates.ts
@@ -19,7 +19,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/templates.regression.test.ts', 'tests/templates-demo.regression.test.ts'],
+    include: [
+      'tests/templates.regression.test.ts',
+      'tests/templates-demo.regression.test.ts',
+      'tests/html-fixtures.regression.test.ts',
+    ],
     exclude: ['node_modules/**'],
   },
   esbuild: {


### PR DESCRIPTION
Experiment per the brief: when a template-regression baseline mismatches, does a semantic diff beat pass/fail? Two information-only changes — the gate is untouched and stays authoritative:

1. **Bump `@pdf-testkit/vitest` 0.1.1 → 0.1.5.** The lockfile pinned a version predating event grouping, so mismatches printed raw event lists (the Discount-column change: 131 flat lines). At 0.1.5 the same failure reads as the story: `table grew +15 rows, +81 cells (6×4 → 21×5), now spans pages 1–2`, related events collapsed.
2. **Tee the Test Templates output; on failure, extract the diff blocks into the job summary** (`packages/core/scripts/semantic-diff-summary.sh`). The matcher already computes and formats the diff; CI was discarding it into scrollback. The summary step cannot fail the build and the experiment removes with one revert (this commit).

Verified by replaying the a260784 baseline change locally: gate fails exactly as before, summary carries the grouped semantic diff. Full replay findings (including two diff gaps this exposed) in the experiment report.