### PR TITLE
Bump pdf-testkit to 0.1.6 (same-page moves + uncharacterized-change)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,7 +508,7 @@ jobs:
         # interchangeably, so skipping the conversion drops a CLI install
         # without changing the diff — verified locally: both forms report
         # zero semantic events against this baseline.
-        uses: danmolitor/pdf-testkit/packages/action@v0.1.4
+        uses: danmolitor/pdf-testkit/packages/action@v0.1.6
         with:
           baseline: packages/core/tests/__pdf_snapshots__/templates.regression.test-template-invoice.json
           current: invoice-layout.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,9 +1855,9 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/core": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.5.tgz",
-      "integrity": "sha512-C1wUtpAJ2cC7syurZ+bq38YGWht3PHFI1HG/PKmH18DHi12J2lYn4czXD03aSJOqORYMZxHZ049JGQrthcK75g==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.6.tgz",
+      "integrity": "sha512-XElRuH9p8xewNGvkpVyHuGPxwW7/0nLQ8HYWqNnfNvsaJLc0g9+H29IFKeVFd+UR++iUJJqMsBiZOjE+r9MK5g==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1870,24 +1870,24 @@
       }
     },
     "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.1.5.tgz",
-      "integrity": "sha512-qfU/7AvhtouzawG9Ue+anfxUSxDj1PpRf28mJa3MWDOA272+VgFt5EJOcNWFfXdPClrlXOspGk1IwsnCXVLuYA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.1.6.tgz",
+      "integrity": "sha512-Uon9l7WZrBVv1t9XH02A+3xre+vP6JM6VR9IYQm3eX+g23j1WO4EbqPwl1QX6fGcAr8X43ani1SgfqYCFTBuOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.1.5"
+        "@pdf-testkit/core": "^0.1.6"
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.1.5.tgz",
-      "integrity": "sha512-GdYYC02dRFfAmwW6pRbV3/9la6kwYgKnk54RcKpkrzfsvSeEz7DuQBppd/xxPK1KI9vTJUvO8nGx58ltlk0eJg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.1.6.tgz",
+      "integrity": "sha512-IVLkE4R+RERXri6XFIv2ZB8TYey+mpiPxkS/NDH++2WxkOy1QyhnW5/CIuAxttRc05L8AfT0/oAO/1mZkzFDxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.1.5",
-        "@pdf-testkit/matcher-core": "^0.1.5"
+        "@pdf-testkit/core": "^0.1.6",
+        "@pdf-testkit/matcher-core": "^0.1.6"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -6722,7 +6722,7 @@
         "@formepdf/fonts-standard": "0.18.0",
         "@formepdf/html": "^0.18.0",
         "@formepdf/templates": "0.18.0",
-        "@pdf-testkit/vitest": "^0.1.5",
+        "@pdf-testkit/vitest": "^0.1.6",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.18.0",
     "@formepdf/html": "^0.18.0",
-    "@pdf-testkit/vitest": "^0.1.5",
+    "@pdf-testkit/vitest": "^0.1.6",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/core/tests/__pdf_snapshots__/pdf-testkit.dogfood.test-invoice.json
+++ b/packages/core/tests/__pdf_snapshots__/pdf-testkit.dogfood.test-invoice.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "producer": "formepdf",
-  "createdAt": "2026-08-26T12:42:33.899Z",
+  "createdAt": "2026-09-05T03:44:40.497Z",
   "pageCount": 1,
   "pages": [
     {
@@ -45,7 +45,7 @@
         "x": 54,
         "y": 54,
         "width": 487.3,
-        "height": 223.2
+        "height": 335.2
       },
       "order": 0,
       "parentId": null,
@@ -171,7 +171,12 @@
       "parentId": "0:container:0",
       "text": null,
       "normText": null,
-      "font": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
       "headingLevel": null,
       "overflow": null,
       "confidence": 1,
@@ -469,5 +474,5 @@
       "confidence": 1
     }
   ],
-  "contentHash": "sha256:60f4bb4ae031f5f1a95def175f7f68f0096f09245a3d9513c3d72854d6a95050"
+  "contentHash": "sha256:9fc1d003adf92766f687bc6cf4bd5a78471f50a8aa4e67dac4dfbe0031fd1f37"
 }


### PR DESCRIPTION
Picks up the dogfood follow-ups published in pdf-testkit 0.1.6: the html fixture baselines become move-aware (a 25pt same-page shift now names itself in the failure message and job summary instead of requiring a hand-run `cmp`), and the demo job's action pin moves to v0.1.6 so PR comments carry the new events. Verified by replaying the a260784 baseline change through the matcher: 143 events, repositioned cells folded into the table-resized story; current baselines green (22/22).