### PR TITLE
Rowspan occupancy in table column assignment

### DIFF
--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -3397,13 +3397,17 @@ impl LayoutEngine {
             font_context,
         );
 
-        let mut header_rows: Vec<&Node> = Vec::new();
-        let mut body_rows: Vec<&Node> = Vec::new();
+        // Column assignments for every row (colspan + rowspan occupancy),
+        // computed once over the authored row order and carried alongside
+        // each row through partitioning.
+        let all_offsets = Self::table_column_offsets(&node.children);
+        let mut header_rows: Vec<(&Node, &[usize])> = Vec::new();
+        let mut body_rows: Vec<(&Node, &[usize])> = Vec::new();
 
-        for child in &node.children {
+        for (child, offs) in node.children.iter().zip(&all_offsets) {
             match &child.kind {
-                NodeKind::TableRow { is_header: true } => header_rows.push(child),
-                _ => body_rows.push(child),
+                NodeKind::TableRow { is_header: true } => header_rows.push((child, offs)),
+                _ => body_rows.push((child, offs)),
             }
         }
 
@@ -3416,7 +3420,8 @@ impl LayoutEngine {
             let total_height: f64 = node
                 .children
                 .iter()
-                .map(|r| self.measure_table_row_height(r, &col_widths, style, font_context))
+                .zip(&all_offsets)
+                .map(|(r, o)| self.measure_table_row_height(r, &col_widths, o, style, font_context))
                 .sum::<f64>()
                 + padding.vertical()
                 + border.vertical();
@@ -3473,11 +3478,11 @@ impl LayoutEngine {
         if !header_rows.is_empty() {
             let total_header_h: f64 = header_rows
                 .iter()
-                .map(|r| self.measure_table_row_height(r, &col_widths, style, font_context))
+                .map(|(r, o)| self.measure_table_row_height(r, &col_widths, o, style, font_context))
                 .sum();
             let first_body_h = body_rows
                 .first()
-                .map(|r| self.measure_table_row_height(r, &col_widths, style, font_context))
+                .map(|(r, o)| self.measure_table_row_height(r, &col_widths, o, style, font_context))
                 .unwrap_or(0.0);
 
             let needed = total_header_h + first_body_h;
@@ -3492,10 +3497,11 @@ impl LayoutEngine {
             }
         }
 
-        for header_row in &header_rows {
+        for (header_row, offs) in &header_rows {
             self.layout_table_row(
                 header_row,
                 &col_widths,
+                offs,
                 style,
                 cursor,
                 cell_x_start,
@@ -3504,9 +3510,9 @@ impl LayoutEngine {
             );
         }
 
-        for body_row in &body_rows {
+        for (body_row, offs) in &body_rows {
             let row_height =
-                self.measure_table_row_height(body_row, &col_widths, style, font_context);
+                self.measure_table_row_height(body_row, &col_widths, offs, style, font_context);
 
             // Break only when a fresh page actually buys room. A row taller
             // than any page (the email-template idiom: everything in one
@@ -3530,10 +3536,11 @@ impl LayoutEngine {
                 *cursor = cursor.new_page();
 
                 cursor.y += padding.top + border.top;
-                for header_row in &header_rows {
+                for (header_row, h_offs) in &header_rows {
                     self.layout_table_row(
                         header_row,
                         &col_widths,
+                        h_offs,
                         style,
                         cursor,
                         cell_x_start,
@@ -3546,6 +3553,7 @@ impl LayoutEngine {
             self.layout_table_row(
                 body_row,
                 &col_widths,
+                offs,
                 style,
                 cursor,
                 cell_x_start,
@@ -3696,11 +3704,59 @@ impl LayoutEngine {
         node.children.iter().any(Self::subtree_forces_break)
     }
 
+    /// Per-row, per-cell starting column for a table's rows, honoring BOTH
+    /// colspan advancement and ROWSPAN OCCUPANCY: a cell with rowspan=N
+    /// keeps its columns occupied for the following N-1 rows, so those
+    /// rows' cells start past it. Without this, the Anvil idiom — a
+    /// rowspan'd name cell beside per-row address lines — assigned the
+    /// address lines to column 1 and right-aligned them mid-page
+    /// (template-compat 02). Pure function of the node tree, so every
+    /// consumer (layout, row measurement, column-content distribution,
+    /// column counting) derives identical assignments.
+    fn table_column_offsets(rows: &[Node]) -> Vec<Vec<usize>> {
+        fn spans(cell: &Node) -> (usize, u32) {
+            match &cell.kind {
+                NodeKind::TableCell { col_span, row_span } => {
+                    ((*col_span).max(1) as usize, (*row_span).max(1))
+                }
+                _ => (1, 1),
+            }
+        }
+        let mut pending: Vec<u32> = Vec::new();
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let mut offsets = Vec::with_capacity(row.children.len());
+            let mut col = 0usize;
+            for cell in &row.children {
+                let (span, rspan) = spans(cell);
+                while pending.get(col).copied().unwrap_or(0) > 0 {
+                    col += 1;
+                }
+                offsets.push(col);
+                if rspan > 1 {
+                    if pending.len() < col + span {
+                        pending.resize(col + span, 0);
+                    }
+                    for slot in pending.iter_mut().take(col + span).skip(col) {
+                        *slot = (*slot).max(rspan);
+                    }
+                }
+                col += span;
+            }
+            out.push(offsets);
+            for p in pending.iter_mut() {
+                *p = p.saturating_sub(1);
+            }
+        }
+        out
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn layout_table_row(
         &self,
         row: &Node,
         col_widths: &[f64],
+        col_offsets: &[usize],
         parent_style: &ResolvedStyle,
         cursor: &mut PageCursor,
         start_x: f64,
@@ -3711,8 +3767,9 @@ impl LayoutEngine {
             .style
             .resolve(Some(parent_style), col_widths.iter().sum());
 
-        let row_height = self.measure_table_row_height(row, col_widths, parent_style, font_context);
-        let row_bl = self.row_baseline(row, &row_style, col_widths);
+        let row_height =
+            self.measure_table_row_height(row, col_widths, col_offsets, parent_style, font_context);
+        let row_bl = self.row_baseline(row, &row_style, col_widths, col_offsets);
         let row_y = cursor.content_y + cursor.y;
         let total_width: f64 = col_widths.iter().sum();
 
@@ -3736,20 +3793,17 @@ impl LayoutEngine {
             row_height > cursor.remaining_height() || Self::subtree_forces_break(row);
 
         let mut all_overflow_pages: Vec<LayoutPage> = Vec::new();
-        let mut cell_x = start_x;
-        // Track the column index separately from the cell index: a colspan
-        // cell consumes several columns' widths, and the next cell must
-        // start past ALL of them. Indexing col_widths by cell position put
-        // every cell after a colspan one slot too far left (found by the
-        // HTML input path's totals rows).
-        let mut col_idx = 0usize;
-        for cell in row.children.iter() {
+        // Column assignment comes from table_column_offsets (colspan
+        // advancement + rowspan occupancy); x and width derive from the
+        // assigned column, never from cell position.
+        for (cell_i, cell) in row.children.iter().enumerate() {
             let span = match &cell.kind {
                 NodeKind::TableCell { col_span, .. } => (*col_span).max(1) as usize,
                 _ => 1,
             };
-            let col_width: f64 = col_widths.iter().skip(col_idx).take(span).copied().sum();
-            col_idx += span;
+            let start_col = col_offsets.get(cell_i).copied().unwrap_or(0);
+            let col_width: f64 = col_widths.iter().skip(start_col).take(span).copied().sum();
+            let cell_x = start_x + col_widths.iter().take(start_col).copied().sum::<f64>();
 
             let cell_style = cell.style.resolve(Some(&row_style), col_width);
 
@@ -3883,8 +3937,6 @@ impl LayoutEngine {
                 overflow: Overflow::default(),
                 opacity: 1.0,
             });
-
-            cell_x += col_width;
         }
 
         // Collect all cell elements as row children
@@ -5929,12 +5981,19 @@ impl LayoutEngine {
                     font_context,
                 );
                 let row_gap = style.row_gap;
+                let offsets = Self::table_column_offsets(&node.children);
                 let mut total = 0.0;
                 for (i, row) in node.children.iter().enumerate() {
                     if i > 0 {
                         total += row_gap;
                     }
-                    total += self.measure_table_row_height(row, &col_widths, style, font_context);
+                    total += self.measure_table_row_height(
+                        row,
+                        &col_widths,
+                        &offsets[i],
+                        style,
+                        font_context,
+                    );
                 }
                 total + style.padding.vertical() + style.border_width.vertical()
             }
@@ -5947,7 +6006,8 @@ impl LayoutEngine {
                 let usable = (available_width - style.margin.horizontal()).max(0.0);
                 let col_w = usable / n as f64;
                 let col_widths = vec![col_w; n];
-                self.measure_table_row_height(node, &col_widths, style, font_context)
+                let offsets = Self::table_column_offsets(std::slice::from_ref(node));
+                self.measure_table_row_height(node, &col_widths, &offsets[0], style, font_context)
             }
             _ => {
                 // If a fixed height is specified, use it directly
@@ -6512,16 +6572,16 @@ impl LayoutEngine {
         row: &Node,
         row_style: &ResolvedStyle,
         col_widths: &[f64],
+        col_offsets: &[usize],
     ) -> Option<f64> {
         let mut b: Option<f64> = None;
-        let mut col_idx = 0usize;
-        for cell in row.children.iter() {
+        for (cell_i, cell) in row.children.iter().enumerate() {
             let span = match &cell.kind {
                 NodeKind::TableCell { col_span, .. } => (*col_span).max(1) as usize,
                 _ => 1,
             };
-            let col_width: f64 = col_widths.iter().skip(col_idx).take(span).copied().sum();
-            col_idx += span;
+            let start_col = col_offsets.get(cell_i).copied().unwrap_or(0);
+            let col_width: f64 = col_widths.iter().skip(start_col).take(span).copied().sum();
             let cell_style = cell.style.resolve(Some(row_style), col_width);
             if matches!(cell_style.vertical_align, VerticalAlign::Baseline) {
                 let iw = col_width
@@ -6538,6 +6598,7 @@ impl LayoutEngine {
         &self,
         row: &Node,
         col_widths: &[f64],
+        col_offsets: &[usize],
         parent_style: &ResolvedStyle,
         font_context: &FontContext,
     ) -> f64 {
@@ -6547,16 +6608,15 @@ impl LayoutEngine {
         let mut max_height: f64 = 0.0;
         // Precompute the row baseline so a baseline-shoved cell can grow the row
         // rather than clip (the risk site).
-        let row_bl = self.row_baseline(row, &row_style, col_widths);
+        let row_bl = self.row_baseline(row, &row_style, col_widths, col_offsets);
 
-        let mut col_idx = 0usize;
-        for cell in row.children.iter() {
+        for (cell_i, cell) in row.children.iter().enumerate() {
             let span = match &cell.kind {
                 NodeKind::TableCell { col_span, .. } => (*col_span).max(1) as usize,
                 _ => 1,
             };
-            let col_width: f64 = col_widths.iter().skip(col_idx).take(span).copied().sum();
-            col_idx += span;
+            let start_col = col_offsets.get(cell_i).copied().unwrap_or(0);
+            let col_width: f64 = col_widths.iter().skip(start_col).take(span).copied().sum();
             let cell_style = cell.style.resolve(Some(&row_style), col_width);
             let inner_width =
                 col_width - cell_style.padding.horizontal() - cell_style.border_width.horizontal();
@@ -6617,9 +6677,10 @@ impl LayoutEngine {
     ) -> (Vec<f64>, Vec<f64>) {
         let mut col_min = vec![0.0f64; num_cols];
         let mut col_max = vec![0.0f64; num_cols];
-        for row_node in children {
-            let mut col = 0usize;
-            for cell in &row_node.children {
+        let offsets = Self::table_column_offsets(children);
+        for (row_i, row_node) in children.iter().enumerate() {
+            for (cell_i, cell) in row_node.children.iter().enumerate() {
+                let col = offsets[row_i].get(cell_i).copied().unwrap_or(0);
                 let span = Self::cell_col_span(cell);
                 let cell_style = cell.style.resolve(Some(table_style), available_width);
                 let chrome = cell_style.padding.horizontal() + cell_style.border_width.horizontal();
@@ -6643,7 +6704,6 @@ impl LayoutEngine {
                     col_min[k] = col_min[k].max(per_min);
                     col_max[k] = col_max[k].max(per_max);
                 }
-                col += span;
             }
         }
         (col_min, col_max)
@@ -6667,9 +6727,20 @@ impl LayoutEngine {
         font_context: &FontContext,
     ) -> Vec<f64> {
         if defs.is_empty() {
+            // Widest row = its last cell's assigned column + span, which
+            // includes columns carried over by rowspans from earlier rows.
+            let offsets = Self::table_column_offsets(children);
             let num_cols = children
                 .iter()
-                .map(|row| row.children.iter().map(Self::cell_col_span).sum::<usize>())
+                .zip(&offsets)
+                .map(|(row, offs)| {
+                    row.children
+                        .iter()
+                        .zip(offs)
+                        .map(|(cell, &start)| start + Self::cell_col_span(cell))
+                        .max()
+                        .unwrap_or(0)
+                })
                 .max()
                 .unwrap_or(1)
                 .max(1);

--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -3704,6 +3704,29 @@ impl LayoutEngine {
         node.children.iter().any(Self::subtree_forces_break)
     }
 
+    /// Occupancy-aware column count: the widest row's last assigned column
+    /// plus its span — includes columns carried by rowspans, so the DEFS
+    /// path and the automatic path agree with layout's assignments (the
+    /// defs path counting with a plain colspan sum starved template-compat
+    /// 05's value column to zero width).
+    fn occupancy_column_count(children: &[Node]) -> usize {
+        let offsets = Self::table_column_offsets(children);
+        children
+            .iter()
+            .zip(&offsets)
+            .map(|(row, offs)| {
+                row.children
+                    .iter()
+                    .zip(offs)
+                    .map(|(cell, &start)| start + Self::cell_col_span(cell))
+                    .max()
+                    .unwrap_or(0)
+            })
+            .max()
+            .unwrap_or(1)
+            .max(1)
+    }
+
     /// Per-row, per-cell starting column for a table's rows, honoring BOTH
     /// colspan advancement and ROWSPAN OCCUPANCY: a cell with rowspan=N
     /// keeps its columns occupied for the following N-1 rows, so those
@@ -6727,23 +6750,7 @@ impl LayoutEngine {
         font_context: &FontContext,
     ) -> Vec<f64> {
         if defs.is_empty() {
-            // Widest row = its last cell's assigned column + span, which
-            // includes columns carried over by rowspans from earlier rows.
-            let offsets = Self::table_column_offsets(children);
-            let num_cols = children
-                .iter()
-                .zip(&offsets)
-                .map(|(row, offs)| {
-                    row.children
-                        .iter()
-                        .zip(offs)
-                        .map(|(cell, &start)| start + Self::cell_col_span(cell))
-                        .max()
-                        .unwrap_or(0)
-                })
-                .max()
-                .unwrap_or(1)
-                .max(1);
+            let num_cols = Self::occupancy_column_count(children);
 
             let (col_min, col_max) = self.measure_column_content(
                 children,
@@ -6794,12 +6801,7 @@ impl LayoutEngine {
         // InvoicePlane date block, template-compat/REPORT.md). Cells
         // beyond the defs used to get NO width at all — extend with Auto
         // columns to the true column count instead.
-        let num_cols = children
-            .iter()
-            .map(|row| row.children.iter().map(Self::cell_col_span).sum::<usize>())
-            .max()
-            .unwrap_or(defs.len())
-            .max(defs.len());
+        let num_cols = Self::occupancy_column_count(children).max(defs.len());
         let mut defs_vec: Vec<ColumnDef> = defs.to_vec();
         while defs_vec.len() < num_cols {
             defs_vec.push(ColumnDef {

--- a/html/tests/table_layout.rs
+++ b/html/tests/table_layout.rs
@@ -300,3 +300,36 @@ fn rowspan_occupancy_composes_with_colspan() {
         d[0].0
     );
 }
+
+#[test]
+fn rowspan_spacer_with_width_defs_extends_columns_to_occupancy_count() {
+    // The InvoicePlane date block (template-compat 05): row 1 is a lone
+    // rowspan=4 spacer with width:40% — harvested as the table's only
+    // column def. Rows 2-4 have label+value cells that occupancy assigns
+    // to columns 2-3, but the DEFS path counted columns with the old
+    // colspan sum (2), so column 3 had no width entry and collapsed to
+    // zero — "03/01/2026" stacked one character per line, and the date
+    // block grew ~10x taller (a corpus regression the page-count sweep
+    // caught before merge).
+    let out = render(
+        "<html><head><style>body{margin:0} table{width:100%} td{padding:0}</style></head><body>\
+         <table>\
+           <tr><td rowspan=\"4\" style=\"width:40%\"></td></tr>\
+           <tr><td>Invoice Date:</td><td>03/01/2026</td></tr>\
+           <tr><td>Due Date:</td><td>03/31/2026</td></tr>\
+           <tr><td>Amount Due:</td><td>$1,821.38</td></tr>\
+         </table></body></html>",
+    );
+    let date = text_lines_containing(&out, "03/01/2026");
+    assert_eq!(
+        date.len(),
+        1,
+        "the date renders as ONE line, not a zero-width per-char stack"
+    );
+    let (x, w) = date[0];
+    assert!(w > 40.0, "value column has real width ({w:.1}pt)");
+    assert!(
+        x > 54.0 + 487.28 * 0.4,
+        "value sits right of the 40% spacer column (x={x:.1})"
+    );
+}

--- a/html/tests/table_layout.rs
+++ b/html/tests/table_layout.rs
@@ -242,3 +242,61 @@ fn shrink_to_fit_container_gives_a_table_its_intrinsic_width() {
         "label line spans the words, not a crushed column ({w:.1}pt wide)"
     );
 }
+
+// ── Rowspan occupancy in column assignment ─────────────────────────
+
+#[test]
+fn rowspan_cell_occupies_its_column_in_following_rows() {
+    // The Anvil shape (template-compat 02): a rowspan=2 cell in column
+    // 1; the next row's single cell is semantically column 2, but
+    // without rowspan occupancy it was assigned column 1 — a
+    // right-aligned address line ended up in the middle of the page.
+    let out = render(
+        "<html><head><style>body{margin:0} td{padding:0} .r{text-align:right}</style></head><body>\
+         <table style=\"width:100%\">\
+           <tr><td rowspan=\"2\">Client Name</td><td class=\"r\">Anvil Co</td></tr>\
+           <tr><td class=\"r\">123 Main Street</td></tr>\
+           <tr><td>Invoice Date</td><td class=\"r\">San Francisco</td></tr>\
+         </table></body></html>",
+    );
+    let street = text_lines_containing(&out, "123 Main Street");
+    let city = text_lines_containing(&out, "San Francisco");
+    assert!(!street.is_empty() && !city.is_empty());
+    let (sx, sw) = street[0];
+    let (cx, cw) = city[0];
+    // Both right-aligned in column 2: their RIGHT edges coincide (and sit
+    // in the right half of the page, not mid-page).
+    assert!(
+        ((sx + sw) - (cx + cw)).abs() < 1.0,
+        "street must right-align with the column-2 city line: street ends {:.1}, city ends {:.1}",
+        sx + sw,
+        cx + cw
+    );
+    assert!(
+        sx > 54.0 + 487.28 / 2.0,
+        "street sits in the right column, not mid-page (x={sx:.1})"
+    );
+}
+
+#[test]
+fn rowspan_occupancy_composes_with_colspan() {
+    // Row 1: A(rowspan=2) B C. Row 2: [A occupies col 1] D(colspan=2)
+    // spanning columns 2-3. D's text must start at column 2's x, and the
+    // table stays 3 columns wide.
+    let out = render(
+        "<html><head><style>body{margin:0} td{padding:0}</style></head><body>\
+         <table style=\"width:100%\">\
+           <tr><td rowspan=\"2\">AA</td><td>BB</td><td>CC</td></tr>\
+           <tr><td colspan=\"2\">DD wide</td></tr>\
+         </table></body></html>",
+    );
+    let b = text_lines_containing(&out, "BB");
+    let d = text_lines_containing(&out, "DD wide");
+    assert!(!b.is_empty() && !d.is_empty());
+    assert!(
+        (b[0].0 - d[0].0).abs() < 1.0,
+        "D starts at column 2 like B: B x={:.1}, D x={:.1}",
+        b[0].0,
+        d[0].0
+    );
+}


### PR DESCRIPTION
Template-compat 02's mis-centered address line diagnosed to the last unmodeled table backlog item: `<td rowspan="2">` occupies column 1 across two rows, so row 2's lone cell is semantically column 2 — but column assignment restarted from zero each row.

One pure function (`table_column_offsets`) now computes per-row per-cell starting columns honoring colspan advancement **and** rowspan occupancy; layout, row measurement, baseline alignment, column-content distribution, and automatic column counting all derive from it, so no consumer can disagree. Cell x/width come from the assigned column, never cell position.

- Fails-first pins: the Anvil shape + rowspan×colspan composition
- Gates: engine 562/0 (visual 9/9), html 189/0, byte wall vs main all 6 IDENTICAL, 28 structural baselines green
- Corpus, measured: **02 → USABLE** (address column stacks right-aligned under "Anvil Co", Chrome-equivalent) — corpus now **12 USABLE / 3 DEGRADED / 0 BROKEN**

Also carries the 07 diagnosis (no code): its sidebar remnant is an off-screen-parking idiom (`translate(-230px)` + `right:-230px` + `body{overflow-x:hidden}`) hidden in browsers by viewport clipping we don't have — the candidate fixes are semantics decisions in the media-query-viewport family, reported for a deliberate call.