### PR TITLE
Media-query width evaluates against the page box (MQ4)

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -111,9 +111,14 @@ print`, comma lists with a match) join the cascade with normal
 specificity; `@media screen` is excluded silently, exactly like Chrome's
 print path. Templates styled for Puppeteer's print-default render
 correctly. **Feature queries** `min-width` / `max-width` / `width` and
-`orientation` are evaluated against the **page content box** (page size
-minus margins) — a paged renderer has no window, so the page is the only
-honest viewport; `orientation` derives from the page's own dimensions.
+`orientation` are evaluated against the **page box** (the full page
+size), per Media Queries Level 4's definition of `width` for paged
+media. A4 is 794 CSS px wide, so `(min-width: 768px)` is true on A4 —
+matching Chrome's print path, where Bootstrap desktop grids activate.
+(Earlier versions evaluated against the content box — page size minus
+margins — under a "the content box is the only honest viewport"
+rationale; that was a misreading of the spec, corrected here.)
+`orientation` derives from the page's own dimensions.
 `print and (min-width: 600px)` and `and`-chains of evaluable features
 evaluate fully. Anything still unmodeled (`prefers-color-scheme`, `not`,
 etc.) keeps the conservative exclude-with-named-warning — rules never
@@ -136,10 +141,12 @@ collected from GitHub — Bootstrap 2/3 float grids, mPDF- and
 wkhtmltopdf-era table layouts, nested-table email HTML, modern CSS grid
 — none written with this engine in mind. Measured against Chrome print
 output: **11 of 15 render correctly; the other 4 degrade legibly with
-every cause named in `warnings`; zero render broken.** The four
-degraded cases share known causes (a `position: running()` stray, an
-admin-shell sidebar, and two templates whose grids only activate above
-a 768px viewport — a media-query semantics question, not a layout gap).
+every cause named in `warnings`; zero render broken.** Each
+degraded case has a named cause: `rowspan` column occupancy, an
+admin-shell sidebar parked off-viewport (hidden in browsers by
+`overflow-x: hidden` clipping), `display: table`/`table-cell` on divs
+(the pre-flexbox equal-height-columns idiom), and attribute selectors
+(`[class*="span"]` — Bootstrap 2's entire grid).
 
 **How this compares.** wkhtmltopdf (archived 2023) and DomPDF never
 shipped margin boxes or reliable break control. Chrome only gained

--- a/html/src/lib.rs
+++ b/html/src/lib.rs
@@ -200,10 +200,15 @@ pub fn html_to_document(html: &str, options: &HtmlOptions) -> (forme::Document, 
         probe.append(sheet::parse_stylesheet(css, &mut probe_warn));
     }
     let probe_config = page_config(options, probe.page.as_ref(), &mut probe_warn);
+    // Media Queries Level 4: in paged media the `width` feature is the width
+    // of the PAGE BOX, not the content area. A4 = 794 CSS px, so
+    // `(min-width: 768px)` is true on A4 — Chrome's print path agrees
+    // (Bootstrap desktop grids activate in print). We previously evaluated
+    // against the content box; that was a spec misreading.
     let (pw, ph) = probe_config.size.dimensions();
     let viewport = sheet::Viewport {
-        width: pw - probe_config.margin.left - probe_config.margin.right,
-        height: ph - probe_config.margin.top - probe_config.margin.bottom,
+        width: pw,
+        height: ph,
     };
 
     // Pass 2 (real): parse with the viewport bound so feature queries evaluate.

--- a/html/tests/polish.rs
+++ b/html/tests/polish.rs
@@ -400,3 +400,45 @@ fn running_position_removes_the_element_from_flow() {
         "siblings unaffected"
     );
 }
+
+#[test]
+fn media_width_evaluates_against_the_page_box() {
+    // MQ Level 4: for paged media, the width feature is the width of the
+    // PAGE BOX — the full page, not the content area. A4 is 595.28pt =
+    // 794 CSS px, so (min-width: 768px) is TRUE on A4 (Chrome print
+    // agrees; Bootstrap desktop grids activate). We evaluated against
+    // the content box (487pt = 650px) under a "the page content box is
+    // the only honest viewport" doctrine that was a spec misreading.
+    let (doc, _) = html_to_document(
+        "<html><head><style>\
+         p { color: rgb(0, 0, 0) }\
+         @media (min-width: 768px) { p { color: rgb(255, 0, 0) } }\
+         @media (min-width: 900px) { p { color: rgb(0, 255, 0) } }\
+         </style></head><body><p>gated</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    let text = first_text_color(&doc.children).expect("styled text");
+    // 768px = 576pt <= 595.28 page width -> red applies.
+    // 900px = 675pt > 595.28 -> green does not.
+    assert!(
+        text.r > 0.9 && text.g < 0.1,
+        "min-width:768px must pass on A4 (page box 794px): got rgb({},{},{})",
+        text.r,
+        text.g,
+        text.b
+    );
+}
+
+fn first_text_color(nodes: &[Node]) -> Option<forme::style::Color> {
+    for n in nodes {
+        if let NodeKind::Text { .. } = &n.kind {
+            if let Some(c) = n.style.color {
+                return Some(c);
+            }
+        }
+        if let Some(c) = first_text_color(&n.children) {
+            return Some(c);
+        }
+    }
+    None
+}

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed (behavior — `@media` width now measures the page box)
+
+- **Media-query `width` evaluates against the page box, not the content box.** Media Queries Level 4 defines `width` in paged media as the width of the page box; Chrome's print path agrees (A4 = 794 CSS px, so `(min-width: 768px)` is true on A4 and Bootstrap desktop grids activate). Earlier versions measured the content box (page minus margins) under a "content box is the only honest viewport" rationale — a spec misreading. Only queries whose threshold falls between your content-box and page-box widths (typically the 650–794px band on default A4) change outcome; the 15-template compat corpus renders identically.
+
 ### Fixed
 
 - **Vertical centering in fixed-height boxes works via flex.** `display: flex; align-items: center` (and `flex-end`) on a fixed-height box now actually aligns its content — the flex line was previously sized at the content's own height, making cross-axis alignment a silent no-op (the logo-mark idiom: a 36×36 box with two letters). Engine fix; see `engine/CHANGELOG.md` for the behavior note.


### PR DESCRIPTION
## What

`@media` feature queries (`width` / `min-width` / `max-width`) now evaluate against the **page box** instead of the content box (page minus margins).

## Why

Media Queries Level 4 defines `width` in paged media as the width of the page box. Chrome's print path agrees: A4 = 794 CSS px ≥ 768, so Bootstrap desktop grids activate in Chrome print. Our content-box choice — documented in the README as "the page is the only honest viewport" — was a spec misreading. The README now says so plainly.

## Impact

- **Zero measured corpus change** (all 15 compat templates render identically) and all six byte-wall fixtures IDENTICAL vs main.
- Only queries with thresholds between the content-box and page-box widths (typically the 650–794px band on default A4) change outcome. Behavior-change entry added to the html changelog.

## Tests

- New pin `media_width_evaluates_against_the_page_box`: `min-width: 768px` applies on A4, `min-width: 900px` does not (fails on main).
- Full html suite green; clippy clean; byte-wall vs main all IDENTICAL.

Also corrects the README's stale degraded-causes sentence (the "two templates whose grids only activate above a 768px viewport" claim was wrong — those two are attribute selectors and `display: table` on divs, per the viewport investigation).