### PR TITLE
Page-level overflow-x clip + position:fixed policy

### DIFF
--- a/docs/guides/migrating-from-wkhtmltopdf.mdx
+++ b/docs/guides/migrating-from-wkhtmltopdf.mdx
@@ -25,6 +25,7 @@ Three things make this migration gentler than you'd expect:
 ## What to check
 
 - **Headers/footers**: wkhtmltopdf's `--header-html`/`--footer-html` flags become `@page` margin boxes with `counter(page)` / `counter(pages)` — see [HTML Input → Paged media](/html).
+- **The `position: fixed` footer pattern works, with these semantics**: `#footer { position: fixed; bottom: 0 }` sits flush at the bottom of the page it occurs on — fixed anchors like absolute, because a paged renderer's viewport is the page. It does **not** repeat on every page the way wkhtmltopdf repeated it; for a footer on every page, use an `@page` margin box (that's what they're for). A render-time warning names this difference whenever `position: fixed` appears.
 - **Remote assets**: Forme never fetches over the network. Inline images as data URIs or local files; pass stylesheets with `--css`.
 - **Fonts**: system-font dependence becomes explicit — pass TTFs with `--font Family=path.ttf`.
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`PageConfig.clipContentX`** — clips page content horizontally to the content box (page width minus left/right margins), spanning the full page height. Visual-only: layout, page breaks, and structural output are unchanged; ink outside the content box's x-range never paints. The HTML input path sets it for `body { overflow-x: hidden }` (the off-viewport-parking idiom); JSON callers can set it directly. Off by default — output without the flag is byte-identical.
+
 ### Fixed (behavior — fixed-height flex rows may align differently)
 
 - **Single-line flex rows honor the container's definite cross size** (CSS 9.4.8). The flex line was sized at the tallest item, never the container — so `align-items: center`/`flex-end` on a fixed-height `nowrap` row was a silent no-op (a 36pt logo box "centered" its 20pt text inside a 20pt line, i.e. top-aligned). Rows with a fixed height and cross-axis alignment now actually align; `stretch` items in such rows now fill the container, per spec. Found two minutes before a launch post, in the standard logo-mark idiom.

--- a/engine/src/model/mod.rs
+++ b/engine/src/model/mod.rs
@@ -365,6 +365,15 @@ pub struct PageConfig {
     /// Where the background image is positioned within the page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_position: Option<BackgroundPosition>,
+
+    /// Clip page content horizontally to the content box (page width
+    /// minus left/right margins). The paged equivalent of a browser
+    /// honoring `body { overflow-x: hidden }`: layout is unaffected,
+    /// but ink outside the content box's x-range never paints — the
+    /// off-viewport-parking idiom (`right: -230px` sidebars) disappears
+    /// instead of smearing into the margin. Vertical ink is not clipped.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub clip_content_x: bool,
 }
 
 /// How a background image is scaled to fit a page.
@@ -403,6 +412,7 @@ impl Default for PageConfig {
             background_opacity: None,
             background_size: None,
             background_position: None,
+            clip_content_x: false,
         }
     }
 }

--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -1349,6 +1349,19 @@ impl PdfWriter {
             self.write_page_background(&mut stream, page, img_idx, builder);
         }
 
+        // Horizontal content clip (`PageConfig.clip_content_x`): the paged
+        // equivalent of `body { overflow-x: hidden }`. X is clipped to the
+        // content box; Y spans the full page so nothing vertical is lost.
+        let clip_x = page.config.clip_content_x;
+        if clip_x {
+            let x = page.config.margin.left;
+            let w = page.width - page.config.margin.left - page.config.margin.right;
+            stream.push_str(&format!(
+                "q\n{:.2} 0 {:.2} {:.2} re W n\n",
+                x, w, page.height
+            ));
+        }
+
         for element in &page.elements {
             self.write_element(
                 &mut stream,
@@ -1363,6 +1376,10 @@ impl PdfWriter {
                 tag_builder.as_deref_mut(),
                 flatten_forms,
             );
+        }
+
+        if clip_x {
+            stream.push_str("Q\n");
         }
 
         stream

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -12376,3 +12376,41 @@ fn sentinel_default_font_documents_are_unchanged() {
         "default-font documents must keep exactly Helvetica"
     );
 }
+
+#[test]
+fn clip_content_x_wraps_page_content_in_a_clip_path() {
+    // `PageConfig.clipContentX` — the paged equivalent of a browser
+    // honoring `body { overflow-x: hidden }`. The page's content stream
+    // must open with a clip rect spanning the content box horizontally
+    // and the FULL page vertically (nothing vertical is lost), and the
+    // clip must be popped at the end.
+    let json = r#"{
+        "children": [
+            { "kind": { "type": "Text", "content": "clipped page" }, "style": {} }
+        ],
+        "defaultPage": {
+            "clipContentX": true,
+            "margin": { "top": 54, "right": 54, "bottom": 54, "left": 54 }
+        }
+    }"#;
+    let bytes = forme::render_json(json).expect("Should parse clip JSON");
+    assert_valid_pdf(&bytes);
+    let ops = decompress_pdf_streams(&bytes);
+    // A4 default: margin 54, page 595.28 x 841.89 -> content width 487.28.
+    assert!(
+        ops.contains("54.00 0 487.28 841.89 re W n"),
+        "clip rect must cover content-box x and full-page y: {ops}"
+    );
+
+    // And without the flag, no page-level clip is emitted.
+    let json_plain = r#"{
+        "children": [
+            { "kind": { "type": "Text", "content": "unclipped page" }, "style": {} }
+        ]
+    }"#;
+    let plain_ops = decompress_pdf_streams(&forme::render_json(json_plain).unwrap());
+    assert!(
+        !plain_ops.contains("re W n"),
+        "no clip path without clipContentX"
+    );
+}

--- a/html/README.md
+++ b/html/README.md
@@ -75,7 +75,9 @@ noted in the warnings).
 |---|---|
 | `margin`, `padding` (+ longhands, 1–4 value shorthands), CSS margin collapsing | |
 | `float: left/right` + `clear` — **as column rows, not text wrap**: runs of consecutive floated siblings form one row (left floats in order, right floats stacking right-to-left, over-wide runs dropping to new float lines, shrink-to-fit auto widths), which is the shape real templates use floats for (Bootstrap `col-*`, left/right header pairs). Per CSS, `float` is ignored on flex items and table-internal elements. | Text wrapping **alongside** a float — a non-floated sibling after an uncleared float renders below it, not beside it, and warns: `text wrapping alongside floats is not supported; floated siblings are laid out as columns` |
-| `border`, `border-top/right/bottom/left`, `border-width`, `border-color`, `border-radius`, `border-style` (`solid`/`dashed`/`dotted`, per side). Dash metrics match Chrome: dashed = dash 2×width / gap 1×width; dotted = round dots, diameter 1×width, 2×width centre spacing. `double`/`groove`/`ridge`/`inset`/`outset` fall back to solid. Under a dashed/dotted border, `border-radius` is dropped (per-side straight strokes), as Chrome does for dashed corners. | `position: fixed/sticky`, transforms, animation |
+| `border`, `border-top/right/bottom/left`, `border-width`, `border-color`, `border-radius`, `border-style` (`solid`/`dashed`/`dotted`, per side). Dash metrics match Chrome: dashed = dash 2×width / gap 1×width; dotted = round dots, diameter 1×width, 2×width centre spacing. `double`/`groove`/`ridge`/`inset`/`outset` fall back to solid. Under a dashed/dotted border, `border-radius` is dropped (per-side straight strokes), as Chrome does for dashed corners. | `position: sticky` (stays in flow, warned), transforms, animation |
+| `position: fixed` — **as `position: absolute`, by policy**: anchored to its containing block on the page where it occurs (a paged renderer's viewport is the page). It does not repeat on every page — margin boxes are the way to get running content — and the warning says so. `#footer { position: fixed; bottom: 0 }` sits at the page bottom. | |
+| `body { overflow-x: hidden }` — **a page-level clip**: content is clipped horizontally to the page content box (full page height), the paged equivalent of a browser suppressing horizontal overflow. This is how off-viewport-parked furniture (`right: -230px` sidebars) stays invisible. | `overflow-x` on other elements (warned; body only); `overflow-y: hidden` (refused by name — content paginates); element-level `overflow: hidden` clipping |
 | `border-collapse` on tables (single-owner-per-edge emulation; `tr` borders redistribute to cells; CSS's widest-border-wins conflict rule is approximated — the earlier edge wins; `border-radius` is ignored under collapse, per spec and Chrome) | |
 | `break-inside: avoid` on `<tr>` — honored: rows are atomic by engine design. A row taller than the page content area is **not** sliced across pages; it is placed whole and overflows (atomicity is the guarantee, not fragmentation). | `break-inside` on `<thead>`/`<tbody>` — pending; use it on the table. Slicing an over-tall row across pages is out of scope. |
 | `width`, `height` (`px`, `pt`, `em`, `rem`, `%`, `in`, `cm`, `mm`) | |
@@ -141,13 +143,13 @@ legacy alias opening its own page. Frozen reference:
 collected from GitHub — Bootstrap 2/3 float grids, mPDF- and
 wkhtmltopdf-era table layouts, nested-table email HTML, modern CSS grid
 — none written with this engine in mind. Measured against Chrome print
-output: **11 of 15 render correctly; the other 4 degrade legibly with
-every cause named in `warnings`; zero render broken.** Each
-degraded case has a named cause: `rowspan` column occupancy, an
-admin-shell sidebar parked off-viewport (hidden in browsers by
-`overflow-x: hidden` clipping), `display: table`/`table-cell` on divs
-(the pre-flexbox equal-height-columns idiom), and attribute selectors
-(`[class*="span"]` — Bootstrap 2's entire grid).
+output: **14 of 15 render correctly; the one degraded case is legible
+with its cause named in `warnings`; zero render broken.** The remaining
+gap is `display: table`/`table-cell` on divs — the pre-flexbox
+equal-height-columns idiom. (The campaign that got here closed, in
+order: automatic table layout, floats-as-rows, whitespace and fixed
+dimensions, table sections, `rowspan` occupancy, attribute selectors,
+and the page-level `overflow-x` clip + `position: fixed` policy.)
 
 **How this compares.** wkhtmltopdf (archived 2023) and DomPDF never
 shipped margin boxes or reliable break control. Chrome only gained

--- a/html/src/css.rs
+++ b/html/src/css.rs
@@ -125,6 +125,9 @@ pub struct CssStyle {
     pub min_height: Option<Length>,
     pub position_absolute: Option<bool>,
     pub position_relative: Option<bool>,
+    /// `overflow-x: hidden|clip` (or via the `overflow` shorthand).
+    /// Honored on `body` only, as a page-level horizontal clip.
+    pub overflow_x_hidden: Option<bool>,
     /// `position: running(<ident>)` — out of subset, but per CSS GCPM the
     /// element leaves normal flow, so the mapper must SUPPRESS it (the
     /// in-flow render was the bug, not the missing feature).
@@ -224,6 +227,7 @@ impl CssStyle {
             position_absolute,
             position_relative,
             position_running,
+            overflow_x_hidden,
             top,
             right,
             bottom,
@@ -579,10 +583,24 @@ pub(crate) fn apply_declaration(
                     // `static` is the plain default.
                     "relative" => style.position_relative = Some(true),
                     "static" => style.position_absolute = Some(false),
-                    other @ ("fixed" | "sticky") => {
-                        warnings.push(format!(
-                            "position: {other} is unsupported (use a margin box for running content)"
-                        ));
+                    // Deliberate fallback policy: a paged renderer's
+                    // "viewport" is the page, so `fixed` anchors like
+                    // `absolute` — to its containing block, on the page
+                    // where it occurs. It does NOT repeat on every page
+                    // (use a margin box for running content); the warning
+                    // names that difference.
+                    "fixed" => {
+                        style.position_absolute = Some(true);
+                        warnings.push(
+                            "position: fixed is rendered as position: absolute — anchored on the page where it occurs, not repeated on every page (use a margin box for running content)"
+                                .to_string(),
+                        );
+                    }
+                    "sticky" => {
+                        warnings.push(
+                            "position: sticky is unsupported (element stays in normal flow)"
+                                .to_string(),
+                        );
                     }
                     other => warnings.push(format!("unsupported position value '{other}'")),
                 }
@@ -710,6 +728,33 @@ pub(crate) fn apply_declaration(
         "max-width" => style.max_width = parse_length(p),
         "min-width" => style.min_width = parse_length(p),
         "min-height" => style.min_height = parse_length(p),
+
+        // Overflow, page-level subset: `overflow-x: hidden` on `body`
+        // becomes a horizontal clip to the page content box (the print
+        // equivalent of a browser suppressing horizontal overflow — how
+        // off-viewport-parked furniture stays invisible). Anywhere else
+        // the mapper warns. The vertical axis has a fixed answer in a
+        // paged renderer — content paginates — so `overflow-y: hidden`
+        // is refused by name rather than clipping pages away.
+        "overflow-x" | "overflow" => {
+            if let Ok(id) = p.expect_ident() {
+                match id.to_ascii_lowercase().as_str() {
+                    "hidden" | "clip" => style.overflow_x_hidden = Some(true),
+                    "visible" | "auto" | "scroll" => style.overflow_x_hidden = Some(false),
+                    other => warnings.push(format!("unsupported overflow value '{other}'")),
+                }
+            }
+        }
+        "overflow-y" => {
+            if let Ok(id) = p.expect_ident() {
+                match id.to_ascii_lowercase().as_str() {
+                    "hidden" | "clip" => warnings.push(
+                        "overflow-y: hidden is not supported (content paginates)".to_string(),
+                    ),
+                    _ => {} // visible/auto/scroll: pagination is the policy anyway
+                }
+            }
+        }
         "max-height" => {
             warnings.push("max-height is pending (clipping semantics undecided)".to_string());
         }

--- a/html/src/map.rs
+++ b/html/src/map.rs
@@ -58,6 +58,9 @@ pub struct Mapper {
     /// Whether ANY rule or inline style floats — the same zero-cost gate
     /// for the float-run transform.
     uses_floats: bool,
+    /// Set when `body` computes `overflow-x: hidden` — becomes the page
+    /// config's horizontal content clip.
+    body_clip_x: bool,
 }
 
 /// Does any inline style in the tree mention float? (Cheap substring
@@ -73,7 +76,11 @@ fn dom_mentions_float(el: &Element) -> bool {
 }
 
 /// Map a parsed `<body>` element to a complete engine document.
-pub fn map_html(body: &Element, sheet: Stylesheet, page: PageConfig) -> (Document, Vec<String>) {
+pub fn map_html(
+    body: &Element,
+    sheet: Stylesheet,
+    mut page: PageConfig,
+) -> (Document, Vec<String>) {
     let mut mapper = Mapper {
         warnings: Vec::new(),
         sheet,
@@ -83,6 +90,7 @@ pub fn map_html(body: &Element, sheet: Stylesheet, page: PageConfig) -> (Documen
         current_page_name: None,
         uses_page_names: false,
         uses_floats: false,
+        body_clip_x: false,
     };
     mapper.uses_page_names = mapper
         .sheet
@@ -125,6 +133,9 @@ pub fn map_html(body: &Element, sheet: Stylesheet, page: PageConfig) -> (Documen
         }
         None => vec![],
     };
+    if mapper.body_clip_x {
+        page.clip_content_x = true;
+    }
     let doc = Document {
         children,
         metadata: Metadata::default(),
@@ -451,6 +462,21 @@ impl Mapper {
         // text at the top of the page (template-compat 02's "Page of").
         if computed.position_running {
             return None;
+        }
+        if computed.overflow_x_hidden {
+            if el.tag == "body" {
+                // The page-level clip: a browser honoring
+                // `body { overflow-x: hidden }` suppresses horizontal
+                // overflow, which is how off-viewport-parked furniture
+                // (`right: -230px` sidebars) stays invisible. Our
+                // equivalent viewport is the page content box.
+                self.body_clip_x = true;
+            } else {
+                self.warnings.push(format!(
+                    "overflow-x: hidden on <{}> is not supported (honored on body only, as a page-level clip)",
+                    el.tag
+                ));
+            }
         }
         let computed_break_after = computed.break_after;
 

--- a/html/src/style.rs
+++ b/html/src/style.rs
@@ -89,6 +89,9 @@ pub struct Computed {
     /// `position: running()` — the element is out of normal flow; the
     /// mapper drops it (warned at parse time).
     pub position_running: bool,
+    /// `overflow-x: hidden` computed on this element. Honored on `body`
+    /// (page-level clip); warned anywhere else.
+    pub overflow_x_hidden: bool,
     /// Offsets in points, meaningful with `position_absolute` or
     /// `position_relative`.
     pub offsets: [Option<f64>; 4],
@@ -305,6 +308,7 @@ pub fn resolve(css: &CssStyle, parent_font_size: f64, warnings: &mut Vec<String>
         position_absolute: css.position_absolute == Some(true),
         position_relative: css.position_relative == Some(true),
         position_running: css.position_running == Some(true),
+        overflow_x_hidden: css.overflow_x_hidden == Some(true),
         offsets: {
             // Offsets are meaningful for both absolute and relative; on a
             // static box they're inert (warned).

--- a/html/tests/overflow_clip.rs
+++ b/html/tests/overflow_clip.rs
@@ -1,0 +1,122 @@
+//! The page-level horizontal clip (`body { overflow-x: hidden }`) and the
+//! `position: fixed` fallback policy — the pair that resolves the
+//! off-viewport-parking idiom (template-compat 07: an admin-shell
+//! control sidebar parked at `right: -230px`, invisible in browsers
+//! because the body suppresses horizontal overflow).
+
+use forme::model::Position;
+use forme_pdf_html::{html_to_document, render_html, HtmlOptions};
+
+#[test]
+fn body_overflow_x_hidden_sets_the_page_clip() {
+    let (doc, warnings) = html_to_document(
+        "<html><head><style>body { overflow-x: hidden; overflow-y: auto }</style></head>\
+         <body><p>content</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(
+        doc.default_page.clip_content_x,
+        "body overflow-x: hidden must set the page-level clip"
+    );
+    assert!(
+        !warnings.iter().any(|w| w.contains("overflow")),
+        "the honored declaration must not warn: {warnings:?}"
+    );
+}
+
+#[test]
+fn overflow_shorthand_and_clip_value_also_count() {
+    let (doc, _) = html_to_document(
+        "<html><head><style>body { overflow: hidden }</style></head>\
+         <body><p>x</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(doc.default_page.clip_content_x, "overflow shorthand");
+    let (doc, _) = html_to_document(
+        "<html><head><style>body { overflow-x: clip }</style></head>\
+         <body><p>x</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(doc.default_page.clip_content_x, "the clip value");
+}
+
+#[test]
+fn overflow_x_elsewhere_warns_and_does_not_clip() {
+    let (doc, warnings) = html_to_document(
+        "<html><head><style>.wrapper { overflow-x: hidden }</style></head>\
+         <body><div class=\"wrapper\"><p>x</p></div></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(!doc.default_page.clip_content_x);
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("overflow-x: hidden on <div>")),
+        "{warnings:?}"
+    );
+}
+
+#[test]
+fn overflow_y_hidden_is_refused_by_name() {
+    let (doc, warnings) = html_to_document(
+        "<html><head><style>body { overflow-y: hidden }</style></head>\
+         <body><p>x</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(!doc.default_page.clip_content_x);
+    assert!(
+        warnings.iter().any(|w| w.contains("content paginates")),
+        "{warnings:?}"
+    );
+}
+
+#[test]
+fn position_fixed_maps_to_absolute_with_the_policy_warning() {
+    let (doc, warnings) = html_to_document(
+        "<html><body>\
+         <div style=\"position: fixed; top: 0; right: -230px; width: 230px\"><p>parked</p></div>\
+         <p>in flow</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    let body = &doc.children[0];
+    let parked = &body.children[0];
+    assert!(
+        matches!(parked.style.position, Some(Position::Absolute)),
+        "fixed must leave normal flow as absolute"
+    );
+    assert_eq!(parked.style.top, Some(0.0));
+    assert_eq!(parked.style.right, Some(-172.5), "-230px = -172.5pt");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.contains("position: fixed is rendered as position: absolute")),
+        "{warnings:?}"
+    );
+}
+
+#[test]
+fn the_admin_shell_shape_renders_with_the_clip() {
+    // The 07 idiom end to end: a dark fixed block parked past the right
+    // edge, hidden by the body clip. The render must succeed, carry the
+    // clip, and place the parked box beyond the content box where the
+    // clip erases it.
+    let out = render_html(
+        "<html><head><style>\
+         body { overflow-x: hidden; overflow-y: auto }\
+         .sidebar-bg { position: fixed; top: 0; right: -230px; width: 230px; height: 100px; background: #222d32 }\
+         </style></head><body>\
+         <div class=\"sidebar-bg\"></div>\
+         <p>invoice content</p></body></html>",
+        &HtmlOptions::default(),
+    )
+    .expect("render");
+    assert!(out.pdf.starts_with(b"%PDF"), "valid pdf");
+    // The PDF-operator assertion for the clip itself lives in the
+    // engine's integration tests; here the flag on the mapped document
+    // is the contract.
+    let (doc, _) = html_to_document(
+        "<html><head><style>body { overflow-x: hidden }</style></head><body><p>x</p></body></html>",
+        &HtmlOptions::default(),
+    );
+    assert!(doc.default_page.clip_content_x);
+}

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
+- **`body { overflow-x: hidden }` is a page-level clip.** A browser honoring it suppresses horizontal overflow — which is how off-viewport-parked furniture (`right: -230px` admin-shell sidebars) stays invisible. The paged equivalent: page content is clipped horizontally to the content box (full page height; nothing vertical is lost). Honored on `body` only; declared elsewhere it warns by name. `overflow-y: hidden` is refused by name — content paginates. With the `position: fixed` policy below, the compat corpus's template 07 (AdminLTE invoice) loses its stray dark sidebar block and renders structurally like Chrome print.
+
 - **Attribute selectors.** All seven operators — `[attr]`, `[attr=v]`, `[attr~=v]`, `[attr|=v]`, `[attr^=v]`, `[attr$=v]`, `[attr*=v]` — plus the `i` case-insensitivity flag, with class-level specificity per spec. `[class*="span"] { float: left }` is all of Bootstrap 2's grid, so BS2 templates get their columns back (the compat corpus's template 10 flips from one column to its real two-column layout; every other corpus template renders byte-identically). Previously these selectors were skipped with a warning; malformed or namespaced (`[ns|attr]`) ones still are.
+
+### Changed (behavior — `position: fixed` leaves normal flow)
+
+- **`position: fixed` renders as `position: absolute`** — anchored to its containing block on the page where it occurs, not repeated on every page (margin boxes remain the way to get running content; the warning says exactly that). A paged renderer's "viewport" is the page, so fixed-to-viewport anchoring maps to the page's own geometry: `#footer { position: fixed; bottom: 0 }` (the wkhtmltopdf print-footer idiom) now sits flush at the page bottom instead of rendering in flow wherever the markup happened to put it. `position: sticky` stays unsupported (element remains in flow, warned).
 
 ### Changed (behavior — `@media` width now measures the page box)
 


### PR DESCRIPTION
## What

The second and third pieces of the viewport-investigation follow-up, resolving template 07:

1. **`body { overflow-x: hidden }` is a page-level clip.** Engine: new `PageConfig.clipContentX` wraps each page's content stream in a clip spanning the content box horizontally and the **full page vertically** (nothing vertical is lost). Visual-only — layout, breaks, and structure are untouched, and output without the flag is byte-identical. HTML path: honored on `body` only (the browser-viewport equivalent); declared elsewhere it warns by name. `overflow-y: hidden` is refused by name — content paginates.
2. **`position: fixed` renders as `position: absolute`, by policy.** A paged renderer's viewport is the page, so fixed anchors to its containing block on the page where it occurs — not repeated per page; margin boxes remain the running-content mechanism, and the warning says exactly that. `sticky` stays unsupported.

## Measured (clean worktree baseline, fresh binaries both sides)

- **Template 07 (AdminLTE invoice) flips DEGRADED → USABLE**: the stray dark control-sidebar block (parked at `right: -230px`, hidden in browsers by the body clip) disappears; the render is structurally identical to a fresh Chrome print reference (remaining artifacts — `alt="Visa">` text — are broken markup in the template source, present in Chrome too).
- **Template 14's `#footer { position: fixed; bottom: 0 }`** — the wkhtmltopdf print-footer idiom — moves flush to the page bottom, matching print semantics. Intended improvement, noted in the changelog.
- **The other 13 corpus templates and all six byte-wall fixtures are byte-identical.**

Corpus after this + #54 + #56: **14 USABLE / 1 DEGRADED (09, `display: table` on divs) / 0 BROKEN.** README's corpus paragraph updated to the new truth.

## Tests

Engine pin: the clip operators (content-box x, full-page y, popped at stream end; absent without the flag). HTML pins: body clip via longhand/shorthand/`clip` value, elsewhere-warns, `overflow-y` refusal, the fixed→absolute policy (offsets converted, warning text), and the 07 admin-shell shape end to end. Both crates: full suites green, clippy `--all-targets -D warnings` clean, byte-wall IDENTICAL.