### PR TITLE
Release 0.20.0

### DIFF
--- a/docs/html.mdx
+++ b/docs/html.mdx
@@ -57,16 +57,17 @@ This is a deliberately **documented subset** of HTML/CSS, in the spirit of Sator
 | Supported | Not supported (selector skipped, warned) |
 |---|---|
 | Type, class, id, universal; compounds | Pseudo-elements (`::before`, `::after`) |
-| Descendant and child combinators; grouping | Attribute selectors, sibling combinators |
+| Attribute selectors — all seven operators (`[checked]`, `[type=text]`, `[class~=well]`, `[lang\|=en]`, `[href^="https:"]`, `[src$=".png"]`, `[class*="span"]`) + the `i` case flag | Sibling combinators (`+`, `~`); namespaced attribute selectors |
+| Descendant and child combinators; grouping | |
 | `:first-child`, `:last-child`, `:nth-child(even\|odd\|an+b)` | `:only-child` and remaining tree pseudo-classes |
 | `:first-of-type`, `:last-of-type`, `:nth-of-type`, `:nth-last-child`, `:nth-last-of-type` | Interaction pseudo-classes (`:hover`) — permanent: print has no hover |
 | Full cascade with `!important` | |
 
 ### Properties
 
-CSS Grid is supported as a **documented subset** (not all of grid): fr/px/auto/minmax tracks, integer `repeat()` — including Tailwind's `repeat(N, minmax(0, 1fr))` — gaps, spans, and numeric line placement; named lines, areas, `auto-flow`, `auto-fill/fit`, percentage tracks, and negative line numbers warn by name. The full property table lives in the [package README](https://github.com/formepdf/forme/blob/main/html/README.md) — margins with CSS margin collapsing, borders (solid/dashed/dotted with Chrome-matched dash metrics), `border-collapse` emulation, min/max width constraints (the centered-column idiom works), font fallback chains, `text-align: justify` with real Knuth-Plass distribution, `text-transform`, `letter-spacing`, `vertical-align` on cells, flexbox, relative/absolute positioning, and floats as column rows (`float: left/right` + `clear` — consecutive floated siblings form a row, the Bootstrap `col-*` / left-right header-pair shape; text wrapping *alongside* a float is not supported and warns — following content renders below).
+CSS Grid is supported as a **documented subset** (not all of grid): fr/px/auto/minmax tracks, integer `repeat()` — including Tailwind's `repeat(N, minmax(0, 1fr))` — gaps, spans, and numeric line placement; named lines, areas, `auto-flow`, `auto-fill/fit`, percentage tracks, and negative line numbers warn by name. The full property table lives in the [package README](https://github.com/formepdf/forme/blob/main/html/README.md) — margins with CSS margin collapsing, borders (solid/dashed/dotted with Chrome-matched dash metrics), `border-collapse` emulation, min/max width constraints (the centered-column idiom works), font fallback chains, `text-align: justify` with real Knuth-Plass distribution, `text-transform`, `letter-spacing`, `vertical-align` on cells, flexbox, relative/absolute positioning, floats as column rows (`float: left/right` + `clear` — consecutive floated siblings form a row, the Bootstrap `col-*` / left-right header-pair shape; text wrapping *alongside* a float is not supported and warns — following content renders below), CSS tables on divs (`display: table`/`table-row`/`table-cell` — the equal-height-columns idiom; a single-row one becomes a breakable column row), `position: fixed` as `position: absolute` by policy (anchored on the page where it occurs, not repeated per page — margin boxes are the running-content mechanism), and `body { overflow-x: hidden }` as a page-level clip (how off-viewport-parked sidebars stay invisible).
 
-Notable exclusions, all warned by name: CSS variables, `position: fixed/sticky`, transforms, gradients, `@font-face` fetching (use `options.fonts` / `--font` — see the [web-fonts migration recipe](https://github.com/formepdf/forme/blob/main/html/README.md)).
+Notable exclusions, all warned by name: CSS variables, `position: sticky`, transforms, gradients, `@font-face` fetching (use `options.fonts` / `--font` — see the [web-fonts migration recipe](https://github.com/formepdf/forme/blob/main/html/README.md)).
 
 ## The warnings contract
 

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.20.0] - 2026-09-05
 
 ### Added
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "forme-pdf"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "barcoders",
  "base64",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forme-pdf"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "A page-native PDF rendering engine. Layout INTO pages, not onto an infinite canvas."
 license = "MIT"

--- a/html/Cargo.lock
+++ b/html/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "forme-pdf"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "barcoders",
  "base64",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "forme-pdf-html"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64",
  "cssparser",

--- a/html/Cargo.toml
+++ b/html/Cargo.toml
@@ -2,7 +2,7 @@
 name = "forme-pdf-html"
 # Not on the shared release line until it ships — like server/ and rasterizer/
 # it versions independently for now.
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "HTML + print-CSS input path for the forme-pdf engine. Satori for paginated documents."
 license = "MIT"
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cssparser = "0.37.0"
-forme-pdf = { version = "0.19.0", path = "../engine" }
+forme-pdf = { version = "0.20.0", path = "../engine" }
 html5ever = "0.39.0"
 markup5ever_rcdom = "0.39.0"
 serde = { version = "1", features = ["derive"] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6691,10 +6691,10 @@
     },
     "packages/cli": {
       "name": "@formepdf/cli",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/renderer": "0.18.0",
+        "@formepdf/renderer": "0.20.0",
         "chokidar": "^4.0.0",
         "open": "^10.1.0",
         "ws": "^8.18.0"
@@ -6712,16 +6712,16 @@
     },
     "packages/core": {
       "name": "@formepdf/core",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/react": "0.18.0"
+        "@formepdf/react": "0.20.0"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.22.0",
-        "@formepdf/fonts-standard": "0.18.0",
-        "@formepdf/html": "^0.18.0",
-        "@formepdf/templates": "0.18.0",
+        "@formepdf/fonts-standard": "0.20.0",
+        "@formepdf/html": "^0.20.0",
+        "@formepdf/templates": "0.20.0",
         "@pdf-testkit/vitest": "^0.1.6",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -6735,7 +6735,7 @@
     },
     "packages/fonts-standard": {
       "name": "@formepdf/fonts-standard",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "OFL-1.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6745,12 +6745,12 @@
     },
     "packages/hono": {
       "name": "@formepdf/hono",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
-        "@formepdf/templates": "0.18.0"
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
+        "@formepdf/templates": "0.20.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6775,7 +6775,7 @@
     },
     "packages/html": {
       "name": "@formepdf/html",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "bin": {
         "forme-html": "bin/forme-html.js"
@@ -6790,12 +6790,12 @@
     },
     "packages/mcp": {
       "name": "@formepdf/mcp",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
-        "@formepdf/templates": "0.18.0",
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
+        "@formepdf/templates": "0.20.0",
         "@modelcontextprotocol/sdk": "^1.27.0",
         "@types/estree": "^1.0.8",
         "acorn": "^8.16.0",
@@ -6815,12 +6815,12 @@
     },
     "packages/next": {
       "name": "@formepdf/next",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
-        "@formepdf/templates": "0.18.0"
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
+        "@formepdf/templates": "0.20.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6834,13 +6834,13 @@
     },
     "packages/preact": {
       "name": "@formepdf/preact",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/shared": "0.18.0"
+        "@formepdf/shared": "0.20.0"
       },
       "devDependencies": {
-        "@formepdf/react": "0.18.0",
+        "@formepdf/react": "0.20.0",
         "@types/react": "^19.0.0",
         "preact": "^10.19.0",
         "react": "^19.0.0",
@@ -6853,10 +6853,10 @@
     },
     "packages/react": {
       "name": "@formepdf/react",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/shared": "0.18.0"
+        "@formepdf/shared": "0.20.0"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -6870,18 +6870,18 @@
     },
     "packages/renderer": {
       "name": "@formepdf/renderer",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/html": "0.18.0",
-        "@formepdf/react": "0.18.0",
+        "@formepdf/core": "0.20.0",
+        "@formepdf/html": "0.20.0",
+        "@formepdf/react": "0.20.0",
         "esbuild": "^0.28.2"
       },
       "devDependencies": {
-        "@formepdf/preact": "0.18.0",
-        "@formepdf/svelte": "0.18.0",
-        "@formepdf/vue": "0.18.0",
+        "@formepdf/preact": "0.20.0",
+        "@formepdf/svelte": "0.20.0",
+        "@formepdf/vue": "0.20.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "preact": "^10.0.0",
@@ -6897,12 +6897,12 @@
     },
     "packages/resend": {
       "name": "@formepdf/resend",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
-        "@formepdf/templates": "0.18.0"
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
+        "@formepdf/templates": "0.20.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6917,7 +6917,7 @@
     },
     "packages/sdk": {
       "name": "@formepdf/sdk",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -6927,7 +6927,7 @@
     },
     "packages/shared": {
       "name": "@formepdf/shared",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.2.1"
@@ -6939,16 +6939,16 @@
     },
     "packages/svelte": {
       "name": "@formepdf/svelte",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/shared": "0.18.0",
+        "@formepdf/shared": "0.20.0",
         "parse5": "^7.2.1"
       },
       "devDependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
-        "@formepdf/tailwind": "0.18.0",
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
+        "@formepdf/tailwind": "0.20.0",
         "@sveltejs/package": "^2.3.10",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@types/react": "^19.0.0",
@@ -6960,7 +6960,7 @@
         "vitest": "^4.1.0"
       },
       "peerDependencies": {
-        "@formepdf/core": "^0.18.0",
+        "@formepdf/core": "^0.20.0",
         "svelte": "^5.30.0"
       },
       "peerDependenciesMeta": {
@@ -6971,7 +6971,7 @@
     },
     "packages/tailwind": {
       "name": "@formepdf/tailwind",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -6980,10 +6980,10 @@
     },
     "packages/templates": {
       "name": "@formepdf/templates",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/react": "0.18.0"
+        "@formepdf/react": "0.20.0"
       },
       "devDependencies": {
         "react": "^19.0.0",
@@ -7002,10 +7002,10 @@
     },
     "packages/vscode": {
       "name": "forme-pdf",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/renderer": "0.18.0",
+        "@formepdf/renderer": "0.20.0",
         "esbuild-wasm": "^0.24.0"
       },
       "devDependencies": {
@@ -7021,14 +7021,14 @@
     },
     "packages/vue": {
       "name": "@formepdf/vue",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
-        "@formepdf/shared": "0.18.0"
+        "@formepdf/shared": "0.20.0"
       },
       "devDependencies": {
-        "@formepdf/core": "0.18.0",
-        "@formepdf/react": "0.18.0",
+        "@formepdf/core": "0.20.0",
+        "@formepdf/react": "0.20.0",
         "@vitejs/plugin-vue": "^5.2.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
@@ -7037,7 +7037,7 @@
         "vue-tsc": "^2.2.0"
       },
       "peerDependencies": {
-        "@formepdf/core": "^0.18.0",
+        "@formepdf/core": "^0.20.0",
         "vue": "^3.4.0"
       },
       "peerDependenciesMeta": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/cli",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "CLI for Forme PDF rendering engine — dev server with live preview and build command",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/renderer": "0.19.0",
+    "@formepdf/renderer": "0.20.0",
     "chokidar": "^4.0.0",
     "ws": "^8.18.0",
     "open": "^10.1.0"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Engine 0.20.0 WASM: attribute selectors, CSS tables on divs, page-level `overflow-x` clip + `position: fixed` policy, page-box `@media` width, half-leading text baselines (see `engine/CHANGELOG.md` and `packages/html/CHANGELOG.md`)
+
 ## [0.18.0] - 2026-09-03
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/core",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "WASM-powered PDF rendering engine for Forme",
   "type": "module",
   "main": "./dist/index.js",
@@ -64,22 +64,22 @@
     "prepublishOnly": "npm run build && ./scripts/assert-tarball.sh"
   },
   "dependencies": {
-    "@formepdf/react": "0.19.0"
+    "@formepdf/react": "0.20.0"
   },
   "peerDependencies": {
     "react": "^18 || ^19"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",
-    "@formepdf/templates": "0.19.0",
-    "@formepdf/html": "^0.19.0",
+    "@formepdf/templates": "0.20.0",
+    "@formepdf/html": "^0.20.0",
     "@pdf-testkit/vitest": "^0.1.6",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0",
-    "@formepdf/fonts-standard": "0.19.0"
+    "@formepdf/fonts-standard": "0.20.0"
   },
   "files": [
     "dist/",

--- a/packages/fonts-standard/CHANGELOG.md
+++ b/packages/fonts-standard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.15.0] - Unreleased
 
 ### Added

--- a/packages/fonts-standard/package.json
+++ b/packages/fonts-standard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/fonts-standard",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Embeddable, metric-compatible replacements for the standard 14 PDF fonts (Liberation Sans/Serif/Mono, OFL) — for PDF/UA and PDF/A output",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hono/CHANGELOG.md
+++ b/packages/hono/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/hono",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "PDF middleware and responses for Hono — works on Workers, Deno, Bun, Node",
   "type": "module",
   "main": "./dist/index.js",
@@ -13,9 +13,9 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/react": "0.19.0",
-    "@formepdf/core": "0.19.0",
-    "@formepdf/templates": "0.19.0"
+    "@formepdf/react": "0.20.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/templates": "0.20.0"
   },
   "peerDependencies": {
     "hono": ">=4.0.0"

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — @formepdf/html
 
-## [Unreleased]
+## [0.20.0] - 2026-09-05
 
 ### Added
 

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/html",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "HTML + print-CSS to PDF on the Forme engine — pagination, running headers, page counters. No headless browser.",
   "license": "MIT",
   "repository": {

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/mcp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "MCP server for Forme PDF rendering — generate PDFs from AI tools",
   "type": "module",
   "bin": {
@@ -16,9 +16,9 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/core": "0.19.0",
-    "@formepdf/react": "0.19.0",
-    "@formepdf/templates": "0.19.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/react": "0.20.0",
+    "@formepdf/templates": "0.20.0",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@types/estree": "^1.0.8",
     "acorn": "^8.16.0",

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/next",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "PDF route handlers and responses for Next.js App Router",
   "type": "module",
   "main": "./dist/index.js",
@@ -13,9 +13,9 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/react": "0.19.0",
-    "@formepdf/core": "0.19.0",
-    "@formepdf/templates": "0.19.0"
+    "@formepdf/react": "0.20.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/templates": "0.20.0"
   },
   "peerDependencies": {
     "next": ">=14.0.0"

--- a/packages/preact/CHANGELOG.md
+++ b/packages/preact/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/preact",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Preact-native adapter for Forme PDF engine. Same components, same props as @formepdf/react, without the React runtime.",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,13 +18,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@formepdf/shared": "0.19.0"
+    "@formepdf/shared": "0.20.0"
   },
   "peerDependencies": {
     "preact": "^10.19.0"
   },
   "devDependencies": {
-    "@formepdf/react": "0.19.0",
+    "@formepdf/react": "0.20.0",
     "@types/react": "^19.0.0",
     "preact": "^10.19.0",
     "react": "^19.0.0",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "formepdf"
-version = "0.19.0"
+version = "0.20.0"
 description = "Python SDK for the Forme hosted PDF API"
 readme = "README.md"
 license = "MIT"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/react",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "JSX-to-JSON serializer for Forme PDF engine",
   "type": "module",
   "main": "./dist/index.js",
@@ -18,7 +18,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@formepdf/shared": "0.19.0"
+    "@formepdf/shared": "0.20.0"
   },
   "peerDependencies": {
     "react": "^18 || ^19"

--- a/packages/renderer/CHANGELOG.md
+++ b/packages/renderer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- HTML input path rides `@formepdf/html` 0.20.0 (attribute selectors, CSS tables, overflow clip, fixed policy)
+
 ## [0.15.0] - Unreleased
 
 ### Added

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/renderer",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "File-to-PDF rendering pipeline for Forme — bundles TSX, resolves assets, renders via WASM",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,18 +17,18 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@formepdf/core": "0.19.0",
-    "@formepdf/html": "0.19.0",
-    "@formepdf/react": "0.19.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/html": "0.20.0",
+    "@formepdf/react": "0.20.0",
     "esbuild": "^0.28.2"
   },
   "peerDependencies": {
     "react": "^18 || ^19"
   },
   "devDependencies": {
-    "@formepdf/preact": "0.19.0",
-    "@formepdf/svelte": "0.19.0",
-    "@formepdf/vue": "0.19.0",
+    "@formepdf/preact": "0.20.0",
+    "@formepdf/svelte": "0.20.0",
+    "@formepdf/vue": "0.20.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "preact": "^10.0.0",

--- a/packages/resend/CHANGELOG.md
+++ b/packages/resend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/resend",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Render a PDF and email it in one call — Forme + Resend",
   "type": "module",
   "main": "./dist/index.js",
@@ -13,9 +13,9 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/react": "0.19.0",
-    "@formepdf/core": "0.19.0",
-    "@formepdf/templates": "0.19.0"
+    "@formepdf/react": "0.20.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/templates": "0.20.0"
   },
   "peerDependencies": {
     "resend": ">=3.0.0"

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/sdk",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "TypeScript client for the Forme hosted PDF API",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/shared",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Framework-agnostic document model and serialization core shared by Forme adapters",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/svelte",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Svelte-to-JSON serializer for Forme PDF engine",
   "type": "module",
   "main": "./dist/index.js",
@@ -25,11 +25,11 @@
     "test:watch": "npm run embed-preview && vitest"
   },
   "dependencies": {
-    "@formepdf/shared": "0.19.0",
+    "@formepdf/shared": "0.20.0",
     "parse5": "^7.2.1"
   },
   "peerDependencies": {
-    "@formepdf/core": "^0.19.0",
+    "@formepdf/core": "^0.20.0",
     "svelte": "^5.30.0"
   },
   "peerDependenciesMeta": {
@@ -38,9 +38,9 @@
     }
   },
   "devDependencies": {
-    "@formepdf/core": "0.19.0",
-    "@formepdf/react": "0.19.0",
-    "@formepdf/tailwind": "0.19.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/react": "0.20.0",
+    "@formepdf/tailwind": "0.20.0",
     "@sveltejs/package": "^2.3.10",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@types/react": "^19.0.0",

--- a/packages/tailwind/CHANGELOG.md
+++ b/packages/tailwind/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/tailwind",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Tailwind CSS class support for Forme PDF templates",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/templates/CHANGELOG.md
+++ b/packages/templates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.14.0] - 2026-08-28
 
 ### Changed

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/templates",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Shared PDF templates and schemas for Forme",
   "type": "module",
   "main": "./dist/index.js",
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@formepdf/react": "0.19.0"
+    "@formepdf/react": "0.20.0"
   },
   "peerDependencies": {
     "zod": ">=3.0.0"

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Bundles the 0.20.0 engine + HTML WASMs (corpus-campaign fixes, half-leading baselines)
+
 ## [0.15.0] - Unreleased
 
 ### Added

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "forme-pdf",
   "displayName": "Forme PDF Preview",
   "description": "Live PDF preview for React, Preact, Svelte, and Vue templates. Component inspector, layout overlays, and hot reload.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "publisher": "formepdf",
   "license": "MIT",
   "repository": {
@@ -95,7 +95,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@formepdf/renderer": "0.19.0",
+    "@formepdf/renderer": "0.20.0",
     "esbuild-wasm": "^0.24.0"
   },
   "devDependencies": {

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.20.0] - 2026-09-05
+
+### Changed
+
+- Version alignment with the 0.20.0 release line; no functional changes in this package.
+
 ## [0.15.0] - Unreleased
 
 ### Added

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/vue",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Vue-to-JSON serializer for the Forme PDF engine",
   "type": "module",
   "main": "./dist/index.js",
@@ -19,10 +19,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@formepdf/shared": "0.19.0"
+    "@formepdf/shared": "0.20.0"
   },
   "peerDependencies": {
-    "@formepdf/core": "^0.19.0",
+    "@formepdf/core": "^0.20.0",
     "vue": "^3.4.0"
   },
   "peerDependenciesMeta": {
@@ -31,8 +31,8 @@
     }
   },
   "devDependencies": {
-    "@formepdf/core": "0.19.0",
-    "@formepdf/react": "0.19.0",
+    "@formepdf/core": "0.20.0",
+    "@formepdf/react": "0.20.0",
     "@vitejs/plugin-vue": "^5.2.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",


### PR DESCRIPTION
The 0.20.0 release commits — version bump across all packages (npm, engine, html crate, python-sdk), changelog finalization ([Unreleased] → 0.20.0 in engine + html; entries in every package), and the docs subset-table updates (attribute selectors, CSS tables, fixed policy, page clip).

All registries are already live at 0.20.0 (npm ×17, crates.io, PyPI) — this PR lands the matching source on main, which branch protection kept out of the direct release-script push. Tag `v0.20.0` follows the merge.

Pre-publish gates all ran green: full dry run (builds + suites + WASM snapshot hashes + native/WASM byte parity), corpus gate dispositioned at 14/1/0, supply-chain audit clean.