### PR TITLE
Parity artifactSizes: CI path probe + stop unpinning miniflare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,10 +386,14 @@ jobs:
           wasm-pack build --target nodejs --out-dir ../packages/html/pkg-node -- --features wasm
           wasm-pack build --target web    --out-dir ../packages/html/pkg-web  -- --features wasm
           rm -f ../packages/html/pkg-node/.gitignore ../packages/html/pkg-web/.gitignore
-      - name: Install browser + edge runtimes for the baseline
-        # Full puppeteer (bundled Chromium) + miniflare (real workerd). The emitter
-        # prefers puppeteer, falling back to puppeteer-core + system Chrome locally.
-        run: npm i --no-save puppeteer miniflare
+      - name: Install browser runtime for the baseline
+        # Full puppeteer (bundled Chromium). The emitter prefers puppeteer,
+        # falling back to puppeteer-core + system Chrome locally. miniflare is
+        # NOT installed here: unpinned `npm i miniflare` pulled a 5.x alpha
+        # whose constructor change silently broke the workerd column — the
+        # repo's exact-pinned devDependency (miniflare 4) from `npm ci` is the
+        # one the harness must use.
+        run: npm i --no-save puppeteer
       - name: Run benchmark emitter
         # Merges the committed dev baseline with a freshly-measured ci run. A slow
         # or too-large document on this shared runner is recorded as a timeout/OOM

--- a/scripts/parity/benchmarks.mjs
+++ b/scripts/parity/benchmarks.mjs
@@ -344,13 +344,19 @@ async function measureRun() {
 // must say which unit (MB vs MiB) they chose.
 function artifactSizes() {
   const { gzipSync } = zlib;
+  // The same module bytes land in pkg/, pkg-node/, and pkg-web/ — CI's
+  // benchmarks job builds only the node+web targets, so probe all three
+  // and take the first that exists.
   const targets = {
-    htmlWasm: join(REPO, 'packages', 'html', 'pkg', 'forme_pdf_html_bg.wasm'),
-    coreWasm: join(REPO, 'packages', 'core', 'pkg', 'forme_bg.wasm'),
+    htmlWasm: ['pkg', 'pkg-node', 'pkg-web'].map((d) =>
+      join(REPO, 'packages', 'html', d, 'forme_pdf_html_bg.wasm')),
+    coreWasm: ['pkg', 'pkg-node', 'pkg-web'].map((d) =>
+      join(REPO, 'packages', 'core', d, 'forme_bg.wasm')),
   };
   const out = {};
-  for (const [name, p] of Object.entries(targets)) {
-    if (!existsSync(p)) {
+  for (const [name, candidates] of Object.entries(targets)) {
+    const p = candidates.find((c) => existsSync(c));
+    if (!p) {
       out[name] = null;
       continue;
     }


### PR DESCRIPTION
Follow-up to #60 — the first republish carried `artifactSizes: null` because the CI benchmarks job builds only `pkg-node`/`pkg-web` while the emitter probed `pkg/` alone. Now probes all three (same module bytes).

Also the deeper fix for the dead workerd column: the job's `npm i --no-save puppeteer miniflare` installed an unpinned miniflare 5 alpha over the repo's exact pin on every run, so #60's pin never took effect in CI. miniflare now comes only from `npm ci` (pinned 4.x).

After merge, the republished artifact should carry real `htmlWasm`/`coreWasm` bytes and a working workerd column; landing's `check-stats` flips from UNVERIFIED to verified against it.