### PR TITLE
Result-shape parity: passes on every target, by construction

### DIFF
--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`render_with_layout_and_passes()`** — like `render_with_layout()` but also returns the layout-pass count. The plain variant computed the count and discarded it, which is how the HTML package's layout path shipped without `passes` while its published TypeScript type promised one. `render_with_layout()` is unchanged (now a thin wrapper).
+
 ## [0.20.0] - 2026-09-05
 
 ### Added

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -261,7 +261,19 @@ pub fn render_with_warnings_and_passes(
 pub fn render_with_layout(
     document: &Document,
 ) -> Result<(Vec<u8>, LayoutInfo, Vec<String>), FormeError> {
-    let (pages, font_context, _passes, layout_warnings) = layout_with_sentinel_passes(document);
+    render_with_layout_and_passes(document)
+        .map(|(pdf, layout, warnings, _passes)| (pdf, layout, warnings))
+}
+
+/// Like [`render_with_layout`], but also returns the number of layout passes
+/// the render took (1 for the common case; 2-3 when a page-number sentinel's
+/// reserved width needed correction). The plain variant discarded this value,
+/// which is how `renderHtmlWithLayout` shipped without `passes` on every
+/// target while its declared type promised one.
+pub fn render_with_layout_and_passes(
+    document: &Document,
+) -> Result<(Vec<u8>, LayoutInfo, Vec<String>, u32), FormeError> {
+    let (pages, font_context, passes, layout_warnings) = layout_with_sentinel_passes(document);
     let layout_info = LayoutInfo::from_pages(&pages);
     let writer = PdfWriter::new();
     let tagged = document.tagged
@@ -292,7 +304,7 @@ pub fn render_with_layout(
         all.extend(warnings);
         all
     };
-    Ok((pdf, layout_info, warnings))
+    Ok((pdf, layout_info, warnings, passes))
 }
 
 /// Return the number of digits needed to display `n` as a decimal string.

--- a/html/src/lib.rs
+++ b/html/src/lib.rs
@@ -116,6 +116,10 @@ pub struct HtmlLayoutOutput {
     pub pdf: Vec<u8>,
     pub layout: LayoutInfo,
     pub warnings: Vec<String>,
+    /// Number of layout passes the render took — same meaning as
+    /// [`HtmlOutput::passes`]. The layout path dropped this until 0.20.1,
+    /// while the published TypeScript type promised it on every target.
+    pub passes: u32,
 }
 
 fn page_config(
@@ -917,13 +921,14 @@ pub fn render_html_with_layout(
     options: &HtmlOptions,
 ) -> Result<HtmlLayoutOutput, FormeError> {
     let (doc, mut warnings) = html_to_document(html, options);
-    let (pdf, layout, engine_warnings) = forme::render_with_layout(&doc)?;
+    let (pdf, layout, engine_warnings, passes) = forme::render_with_layout_and_passes(&doc)?;
     warnings.extend(engine_warnings);
     let warnings = dedup_warnings(warnings);
     Ok(HtmlLayoutOutput {
         pdf,
         layout,
         warnings,
+        passes,
     })
 }
 
@@ -977,5 +982,22 @@ mod sentinel_pass_tests {
             "page-numbered doc needing a width correction must re-layout, got {} pass(es)",
             out.passes
         );
+    }
+
+    #[test]
+    fn layout_path_reports_the_same_passes_as_the_plain_path() {
+        // The layout-bearing render dropped `passes` entirely until 0.20.1
+        // (the engine computed it and discarded it), while the published
+        // TypeScript type promised the field on every target. Pin the two
+        // paths to the same count, on both a 1-pass and a multi-pass doc.
+        for multi in [false, true] {
+            let plain = render_html(&doc(multi, 3), &HtmlOptions::default()).unwrap();
+            let layout = render_html_with_layout(&doc(multi, 3), &HtmlOptions::default()).unwrap();
+            assert_eq!(
+                layout.passes, plain.passes,
+                "layout path must report the same pass count (multi={multi})"
+            );
+            assert!(layout.passes >= 1);
+        }
     }
 }

--- a/html/src/wasm.rs
+++ b/html/src/wasm.rs
@@ -83,6 +83,7 @@ pub struct HtmlLayoutRenderResult {
     pdf: Vec<u8>,
     layout_json: String,
     warnings: Vec<String>,
+    passes: u32,
 }
 
 #[wasm_bindgen]
@@ -101,6 +102,13 @@ impl HtmlLayoutRenderResult {
     #[wasm_bindgen(getter)]
     pub fn warnings(&self) -> Vec<String> {
         self.warnings.clone()
+    }
+
+    /// Number of layout passes the render took — identical semantics to
+    /// [`HtmlRenderResult::passes`].
+    #[wasm_bindgen(getter)]
+    pub fn passes(&self) -> u32 {
+        self.passes
     }
 }
 
@@ -183,5 +191,6 @@ pub fn render_html_wasm_with_layout(
         pdf: out.pdf,
         layout_json,
         warnings: out.warnings,
+        passes: out.passes,
     })
 }

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — @formepdf/html
 
+## [Unreleased]
+
+### Fixed
+
+- **`passes` is now actually returned everywhere the type declares it.** `RenderHtmlResult.passes` was declared in `index.d.ts` but returned by only one of the six result constructions — the node `renderHtml`. The browser and worker entries, and `renderHtmlWithLayout` on **all three** targets, silently returned `undefined` (the engine computed the value and discarded it on the layout path). All six now return it, verified per target in the real runtime: plain node (`npm test`), real workerd (`npm run test:workers`), and real headless Chromium (`test/browser-verify.mjs`), each asserting the **exact** declared key set, not just the field.
+- **Result construction is shared, not repeated.** All three entries build their result objects through one `result.js` (`toRenderResult`/`toLayoutResult`) — a new field is added in exactly one place. The declared-vs-runtime agreement is compile-checked too: `tests/shape.ts` derives the expected key sets from `keyof RenderHtmlResult` (`npm run typecheck`, part of `npm test`), so a type change that the runtime doesn't match fails the build in both directions.
+
 ## [0.20.0] - 2026-09-05
 
 ### Added

--- a/packages/html/browser.js
+++ b/packages/html/browser.js
@@ -11,6 +11,7 @@ import {
   render_html_wasm_with_layout,
 } from './pkg/forme_pdf_html.js';
 import { toWireOptions } from './wire.js';
+import { toRenderResult, toLayoutResult } from './result.js';
 
 /**
  * No-op under the bundler-target build: the WASM is already instantiated by
@@ -24,32 +25,18 @@ export async function init() {}
  * Render an HTML string to PDF.
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlResult}
  */
 export function renderHtml(html, options = {}) {
-  const result = render_html_wasm(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return { pdf: result.pdf, warnings: result.warnings };
-  } finally {
-    result.free();
-  }
+  return toRenderResult(render_html_wasm(html, JSON.stringify(toWireOptions(options))));
 }
 
 /**
  * Render an HTML string to PDF plus its `LayoutInfo`.
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, layout: import('./index').LayoutInfo, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlLayoutResult}
  */
 export function renderHtmlWithLayout(html, options = {}) {
-  const result = render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return {
-      pdf: result.pdf,
-      layout: JSON.parse(result.layout_json),
-      warnings: result.warnings,
-    };
-  } finally {
-    result.free();
-  }
+  return toLayoutResult(render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options))));
 }

--- a/packages/html/index.js
+++ b/packages/html/index.js
@@ -14,6 +14,7 @@ import {
   render_html_wasm_with_layout,
 } from './pkg-node/forme_pdf_html.js';
 import { toWireOptions } from './wire.js';
+import { toRenderResult, toLayoutResult } from './result.js';
 
 /**
  * No-op on Node: the nodejs target self-initializes. Present so the three
@@ -27,17 +28,12 @@ export async function init() {}
  *
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlResult}
  *   `warnings` lists everything the input asked for that the documented
  *   subset doesn't cover — nothing is silently dropped.
  */
 export function renderHtml(html, options = {}) {
-  const result = render_html_wasm(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return { pdf: result.pdf, warnings: result.warnings, passes: result.passes };
-  } finally {
-    result.free();
-  }
+  return toRenderResult(render_html_wasm(html, JSON.stringify(toWireOptions(options))));
 }
 
 /**
@@ -49,19 +45,8 @@ export function renderHtml(html, options = {}) {
  *
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, layout: import('./index').LayoutInfo, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlLayoutResult}
  */
 export function renderHtmlWithLayout(html, options = {}) {
-  const result = render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return {
-      pdf: result.pdf,
-      // Returned as a JSON string from WASM (the crate's wasm feature omits
-      // serde-wasm-bindgen on purpose); parse it back to the native object.
-      layout: JSON.parse(result.layout_json),
-      warnings: result.warnings,
-    };
-  } finally {
-    result.free();
-  }
+  return toLayoutResult(render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options))));
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@formepdf/html",
   "version": "0.20.0",
-  "description": "HTML + print-CSS to PDF on the Forme engine — pagination, running headers, page counters. No headless browser.",
+  "description": "HTML + print-CSS to PDF on the Forme engine \u2014 pagination, running headers, page counters. No headless browser.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -67,6 +67,7 @@
     "browser.d.ts",
     "worker.js",
     "worker.d.ts",
+    "result.js",
     "wire.js",
     "bin/",
     "pkg/",
@@ -75,8 +76,9 @@
   ],
   "scripts": {
     "build": "./build.sh",
-    "test": "node test/smoke.js && node test/links.js",
-    "test:workers": "vitest run --config vitest.config.workers.ts"
+    "test": "npm run typecheck && node test/smoke.js && node test/links.js",
+    "test:workers": "vitest run --config vitest.config.workers.ts",
+    "typecheck": "tsc -p tsconfig.test.json"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",

--- a/packages/html/result.js
+++ b/packages/html/result.js
@@ -1,0 +1,41 @@
+// @formepdf/html — the ONE place a raw WASM result becomes the public
+// result object.
+//
+// All three entries (node, browser, worker) previously built their result
+// objects field by field, and when `passes` was added only the node
+// `renderHtml` was updated — the declared `RenderHtmlResult` promised a
+// field five of the six constructions never returned. Agreement by
+// construction: every entry funnels through these two functions, so a new
+// field is added exactly here (and in the shape tests that pin
+// declared-vs-runtime agreement per target).
+
+/**
+ * @param {{ pdf: Uint8Array, warnings: string[], passes: number, free(): void }} raw
+ * @returns {import('./index').RenderHtmlResult}
+ */
+export function toRenderResult(raw) {
+  try {
+    return { pdf: raw.pdf, warnings: raw.warnings, passes: raw.passes };
+  } finally {
+    raw.free();
+  }
+}
+
+/**
+ * @param {{ pdf: Uint8Array, layout_json: string, warnings: string[], passes: number, free(): void }} raw
+ * @returns {import('./index').RenderHtmlLayoutResult}
+ */
+export function toLayoutResult(raw) {
+  try {
+    return {
+      pdf: raw.pdf,
+      // The crate's wasm feature returns LayoutInfo as a JSON string on
+      // purpose (no serde-wasm-bindgen); parse it back to a native object.
+      layout: JSON.parse(raw.layout_json),
+      warnings: raw.warnings,
+      passes: raw.passes,
+    };
+  } finally {
+    raw.free();
+  }
+}

--- a/packages/html/test/browser-verify.mjs
+++ b/packages/html/test/browser-verify.mjs
@@ -65,17 +65,22 @@ const MIME = {
 const page = `<!doctype html><meta charset="utf8">
 <script id="fx" type="application/json">${JSON.stringify(fixture)}</script>
 <script type="module">
-  import { init, renderHtmlWithLayout } from '/worker.js';
+  import { init, renderHtml, renderHtmlWithLayout } from '/worker.js';
   (async () => {
     try {
       await init('/pkg-web/forme_pdf_html_bg.wasm');
       const html = JSON.parse(document.getElementById('fx').textContent);
-      const { pdf, layout, warnings } = renderHtmlWithLayout(html, {});
+      const plain = renderHtml(html, {});
+      const res = renderHtmlWithLayout(html, {});
+      const { pdf, layout, warnings } = res;
       window.__RESULT__ = {
         magic: new TextDecoder().decode(pdf.slice(0, 5)),
         length: pdf.length,
         pages: layout.pages.length,
         warnings: warnings.length,
+        resultKeys: Object.keys(plain).sort(),
+        layoutKeys: Object.keys(res).sort(),
+        passes: res.passes,
       };
     } catch (e) {
       window.__RESULT__ = { error: String(e && e.stack || e) };
@@ -134,6 +139,14 @@ assert.strictEqual(
   expectedPages,
   `browser page count ${result.pages} != node page count ${expectedPages}`,
 );
+// Declared-type ↔ runtime shape, in the real browser runtime. The key sets
+// mirror tests/shape.ts, which compile-checks them against index.d.ts.
+assert.deepStrictEqual(result.resultKeys, ['passes', 'pdf', 'warnings'],
+  `browser renderHtml shape: ${result.resultKeys}`);
+assert.deepStrictEqual(result.layoutKeys, ['layout', 'passes', 'pdf', 'warnings'],
+  `browser renderHtmlWithLayout shape: ${result.layoutKeys}`);
+assert.ok(Number.isInteger(result.passes) && result.passes >= 1,
+  `browser passes must be a count, got ${result.passes}`);
 console.log(
   `ok — headless Chromium rendered letterhead via the web build: ` +
     `${result.length}-byte %PDF, ${result.pages} page(s) (matches Node), ${result.warnings} warning(s)`,

--- a/packages/html/test/smoke.js
+++ b/packages/html/test/smoke.js
@@ -23,3 +23,25 @@ const a4 = renderHtml(html, { pageSize: 'A4' });
 assert.ok(a4.pdf.length > 500);
 
 console.log(`ok — ${pdf.length} byte PDF, ${warnings.length} warning(s)`);
+
+// ── declared-type ↔ runtime shape (node target) ────────────────────────
+// Exact key sets, both directions. The canonical lists are compile-checked
+// against index.d.ts in tests/shape.ts (npm run typecheck); these mirror
+// them for the plain-node runner.
+import { renderHtmlWithLayout } from '../index.js';
+
+const RESULT_KEYS = ['passes', 'pdf', 'warnings'];
+const LAYOUT_KEYS = ['layout', 'passes', 'pdf', 'warnings'];
+
+const shapeRes = renderHtml(html, {});
+assert.deepStrictEqual(Object.keys(shapeRes).sort(), RESULT_KEYS,
+  'node renderHtml must return exactly the declared RenderHtmlResult');
+assert.ok(Number.isInteger(shapeRes.passes) && shapeRes.passes >= 1, 'passes is a count');
+
+const shapeLay = renderHtmlWithLayout(html, {});
+assert.deepStrictEqual(Object.keys(shapeLay).sort(), LAYOUT_KEYS,
+  'node renderHtmlWithLayout must return exactly the declared RenderHtmlLayoutResult');
+assert.ok(Number.isInteger(shapeLay.passes) && shapeLay.passes >= 1, 'layout passes is a count');
+assert.strictEqual(shapeLay.passes, shapeRes.passes, 'both paths report the same count');
+
+console.log('ok — result shapes match the declared types (node target)');

--- a/packages/html/tests/shape.ts
+++ b/packages/html/tests/shape.ts
@@ -1,0 +1,32 @@
+// The declared result types and the runtime objects must agree in BOTH
+// directions, on every target. `Record<keyof T, true>` fails to COMPILE
+// (npm run typecheck) whenever `index.d.ts` gains or loses a field this
+// list doesn't mirror; the runtime tests then hold these exact key sets
+// against `Object.keys()` of real results in each runtime. A type that
+// declares a field no target returns is worse than a missing field,
+// because it type-checks — which is exactly how `passes` shipped
+// undefined on five of six constructions.
+import type { RenderHtmlResult, RenderHtmlLayoutResult } from '../index.js';
+
+const RESULT_KEY_RECORD: Record<keyof RenderHtmlResult, true> = {
+  pdf: true,
+  warnings: true,
+  passes: true,
+};
+const LAYOUT_KEY_RECORD: Record<keyof RenderHtmlLayoutResult, true> = {
+  pdf: true,
+  warnings: true,
+  passes: true,
+  layout: true,
+};
+
+export const RESULT_KEYS = Object.keys(RESULT_KEY_RECORD).sort();
+export const LAYOUT_KEYS = Object.keys(LAYOUT_KEY_RECORD).sort();
+
+/** Assertion helper shared by the runtime shape tests (throws on mismatch). */
+export function assertShape(actual: object, expected: string[], label: string): void {
+  const keys = Object.keys(actual).sort();
+  if (keys.join(',') !== expected.join(',')) {
+    throw new Error(`${label}: runtime keys [${keys}] != declared keys [${expected}]`);
+  }
+}

--- a/packages/html/tests/worker.test.ts
+++ b/packages/html/tests/worker.test.ts
@@ -69,3 +69,30 @@ describe('@formepdf/html/worker', () => {
     expect(true).toBe(true);
   });
 });
+
+describe('declared type vs runtime shape (workerd)', () => {
+  it('renderHtml returns the full declared RenderHtmlResult, exactly', async () => {
+    const { init, renderHtml } = await import('../worker.js');
+    // @ts-expect-error -- *.wasm import shape is provided by workerd at runtime
+    const wasm = (await import('../pkg-web/forme_pdf_html_bg.wasm')).default;
+    await init(wasm);
+    const { RESULT_KEYS, assertShape } = await import('./shape.js');
+    const res = renderHtml(INVOICE, {});
+    assertShape(res, RESULT_KEYS, 'worker renderHtml');
+    expect(res.passes).toBeTypeOf('number');
+    expect(res.passes).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renderHtmlWithLayout returns the full declared RenderHtmlLayoutResult, exactly', async () => {
+    const { init, renderHtmlWithLayout } = await import('../worker.js');
+    // @ts-expect-error -- *.wasm import shape is provided by workerd at runtime
+    const wasm = (await import('../pkg-web/forme_pdf_html_bg.wasm')).default;
+    await init(wasm);
+    const { LAYOUT_KEYS, assertShape } = await import('./shape.js');
+    const res = renderHtmlWithLayout(INVOICE, {});
+    assertShape(res, LAYOUT_KEYS, 'worker renderHtmlWithLayout');
+    expect(res.passes).toBeTypeOf('number');
+    expect(res.passes).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(res.layout.pages)).toBe(true);
+  });
+});

--- a/packages/html/tsconfig.test.json
+++ b/packages/html/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["tests/shape.ts", "index.d.ts", "worker.d.ts", "browser.d.ts"]
+}

--- a/packages/html/worker.js
+++ b/packages/html/worker.js
@@ -22,6 +22,7 @@ import __wbg_init, {
   render_html_wasm_with_layout,
 } from './pkg-web/forme_pdf_html.js';
 import { toWireOptions } from './wire.js';
+import { toRenderResult, toLayoutResult } from './result.js';
 
 let initPromise = null;
 
@@ -57,16 +58,11 @@ function ensureInit() {
  * Render an HTML string to PDF. Requires a prior `await init(module)`.
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlResult}
  */
 export function renderHtml(html, options = {}) {
   ensureInit();
-  const result = render_html_wasm(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return { pdf: result.pdf, warnings: result.warnings };
-  } finally {
-    result.free();
-  }
+  return toRenderResult(render_html_wasm(html, JSON.stringify(toWireOptions(options))));
 }
 
 /**
@@ -74,18 +70,9 @@ export function renderHtml(html, options = {}) {
  * `await init(module)`.
  * @param {string} html
  * @param {import('./index').RenderHtmlOptions} [options]
- * @returns {{pdf: Uint8Array, layout: import('./index').LayoutInfo, warnings: string[]}}
+ * @returns {import('./index').RenderHtmlLayoutResult}
  */
 export function renderHtmlWithLayout(html, options = {}) {
   ensureInit();
-  const result = render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options)));
-  try {
-    return {
-      pdf: result.pdf,
-      layout: JSON.parse(result.layout_json),
-      warnings: result.warnings,
-    };
-  } finally {
-    result.free();
-  }
+  return toLayoutResult(render_html_wasm_with_layout(html, JSON.stringify(toWireOptions(options))));
 }


### PR DESCRIPTION
## The diagnosis (before the fix)

Field-by-field, runtime vs the declared `RenderHtmlResult` / `RenderHtmlLayoutResult`, measured per target:

| Field | node `renderHtml` | node `withLayout` | browser `renderHtml` | browser `withLayout` | worker `renderHtml` | worker `withLayout` |
|---|---|---|---|---|---|---|
| `pdf` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `warnings` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `passes` | ✓ | **✗** | **✗** | **✗** | **✗** | **✗** |
| `layout` | — | ✓ | — | ✓ | — | ✓ |

**A class, not a field**: 5 of 6 constructions omitted `passes`, with drops at three depths — three hand-written per-target wrappers (only node `renderHtml` was updated when the field was exposed), a wasm layout binding that never had the field, and the engine's `render_with_layout` computing `_passes` and discarding it. `warnings` and the pdfA/pdfUa error paths flow through one shared binding and are consistent everywhere; `@formepdf/core` declares no `passes` — the class is confined to this package.

## The fix

- Engine: `render_with_layout_and_passes()` (the plain variant is now a thin wrapper; no signature break).
- html crate: `HtmlLayoutOutput.passes` + a pin that the plain and layout paths report the same count on 1-pass and multi-pass documents.
- **Agreement by construction**: one shared `result.js` builds every result object for all three entries.
- **Agreement by assertion**: `tests/shape.ts` derives expected key sets from `keyof RenderHtmlResult` — a type/list mismatch fails `npm run typecheck` (now part of `npm test`); runtime tests assert the exact key set per target **in the real runtime**: plain node, real workerd (`vitest-pool-workers`), and real headless Chromium (`browser-verify`).
- **Fails-first, demonstrated against the registry**: the published 0.20.0 layout path fails the new shape test (`passes: undefined`).

## Gates

Engine (9 suites) + html (23 suites) green; clippy `--all-targets -D warnings` clean both crates; cross-target byte determinism identical (node vs web); byte-wall vs main **IDENTICAL** — the engine change is a pure refactor. Workers tests ran in real workerd; browser check ran in real Chromium locally as well as in CI.