### PR TITLE
Migration guides: complete the wkhtmltopdf, DomPDF, and Puppeteer pages

### DIFF
--- a/docs/guides/migrating-from-dompdf.mdx
+++ b/docs/guides/migrating-from-dompdf.mdx
@@ -1,31 +1,136 @@
 ---
 title: Migrating from DomPDF
 sidebarTitle: From DomPDF
-description: Move DomPDF templates to Forme's HTML input path — real print CSS support, UTF-8 shaping that works, and no PHP memory-limit fights.
+description: Move DomPDF templates to Forme's HTML input path — flexbox for the first time, real print CSS, UTF-8 shaping that works. And the honest part first - you are in PHP and this is a JavaScript library.
 ---
 
-DomPDF renders a useful HTML subset but predates modern print CSS, and its text handling struggles past Latin scripts. Forme's [HTML input path](/html) covers the same document class with a page-native engine: real `@page` rules, margin boxes, OpenType shaping, and BiDi text.
+One thing first, because a guide that buries it loses your trust in the first minute: **you are in PHP, and Forme is not a PHP library.** The engine is Rust compiled to WASM, and the HTML input path runs in Node (CLI or library), the browser, and Cloudflare Workers. Migrating from DomPDF means one of:
 
-## The short version
+- **A rendering step your PHP app shells out to or calls over HTTP** — the `forme-html` CLI on the same box, or a small Node service you own.
+- **Moving PDF generation out of PHP entirely**, if your stack is heading that way anyway.
 
-```bash
-npx @formepdf/html invoice.html -o invoice.pdf
+If neither is acceptable — if it must be `composer require` and in-process — DomPDF (or mPDF/TCPDF) remains your tool, and the rest of this page is not for you. Everyone else, read on: the template itself usually moves with few or no changes, because both tools speak HTML and CSS.
+
+## Why people leave DomPDF
+
+The famous wall is **no flexbox**. DomPDF renders a useful HTML subset, but it predates modern layout: no flexbox, no grid, and partial support across much of CSS 2.1. Every DomPDF template is built from tables and floats because those are the tools that exist there. The secondary reasons are the ones you hit at 2am: UTF-8 and non-Latin scripts needing font gymnastics, PHP memory limits on long documents, and print-CSS features (`@page` margin boxes, page counters, break control) that are partially implemented or absent.
+
+None of that is a criticism of a library that has carried PHP PDF generation for fifteen years. It is why the migrations happen.
+
+## What moves over unchanged
+
+Your DomPDF template is HTML + CSS, and the dialect DomPDF taught you is inside Forme's subset:
+
+- **Tables**, including `<thead>` repeating on every page, `colspan`/`rowspan`, and `border-collapse` with Chrome-matched edge resolution. Cell overflow is preserved across page breaks.
+- **Floats lay out as columns** — the two-column address block, the `float: right` totals box, cleared sections. The one unsupported float case is text wrapping *alongside* a float (content renders below instead, with a warning naming it).
+- **The cascade as written**: type/class/id selectors, compounds, combinators, attribute selectors, `!important`.
+- **Print CSS, properly**: `@page` size and margins, `:first` variants, margin boxes with `counter(page)` / `counter(pages)`, `break-*` and the legacy `page-break-*` spellings, `orphans`/`widows`.
+- **Text you don't have to fight**: OpenType shaping (ligatures, kerning), font fallback chains, automatic hyphenation, justified text with real inter-word distribution, BiDi for RTL scripts.
+
+And the thing you have never had: **flexbox.** A DomPDF template doesn't use it, but the first template you touch after migrating can.
+
+```css
+@page {
+  size: A4;
+  margin: 20mm;
+  @bottom-center { content: "Page " counter(page) " of " counter(pages); }
+}
+.header { display: flex; justify-content: space-between; }  /* new to you */
+.addresses .left  { float: left;  width: 48%; }             /* works as-is */
+.addresses .right { float: right; width: 48%; }
+tr { page-break-inside: avoid; }
 ```
 
-Or from a PHP-adjacent stack, call the library from a small Node sidecar or use the [Python SDK](/python-sdk) — the engine is the same WASM everywhere.
+## What doesn't, up front
 
-## What improves
+- **No JavaScript execution** (DomPDF doesn't run it either, so nothing changes here).
+- **Nothing fetched over the network.** Remote images and fonts are never downloaded. Inline images as data URIs or local paths; pass fonts explicitly with `--font Family=path.ttf` — no font-directory installation dance, but also no implicit system fonts.
+- **A documented subset, not all of CSS.** Everything outside it — transforms, gradients, CSS variables — warns by name at render time instead of rendering differently in silence. The [subset table](/html) is the reference, and the warnings list from one render of your own template is the ground truth.
 
-- **Print CSS**: `@page` size/margins, `:first` variants, margin boxes with page counters, `break-*` control, `orphans`/`widows` — the features DomPDF partially implements are the core of Forme's subset.
-- **Text**: OpenType shaping (ligatures, kerning), font fallback chains, automatic hyphenation, justified text with real inter-word distribution, BiDi for RTL scripts.
-- **Tables**: `<thead>` repeats on every page; `border-collapse` is emulated with Chrome-matched edge resolution; cell overflow is preserved across breaks.
-- **Floats lay out as columns**: the DomPDF-era idioms — two-column address blocks, `float: right` totals, cleared sections — render as real columns. The one unsupported float case is text wrapping *alongside* a float (content renders below instead), and it warns by name.
-- **Measured, not promised**: of 15 production templates in our compat corpus — two of them stock Crater designs written for DomPDF — **14 render correctly at 0.20.0, 1 degrades legibly with its cause named in warnings, 0 broken** ([how it was measured](https://formepdf.com/blog/template-compat-endgame)).
+## Before and after
 
-## What to check
+**Before — DomPDF, in-process PHP:**
 
-- **The subset is documented, not guessed** — compare your template against the [subset tables](/html). Everything outside it warns by name at render time; run once and read the warnings.
-- **Remote assets**: never fetched. Inline images as data URIs/local files; pass extra CSS with `--css`.
-- **Fonts**: pass TTFs explicitly with `--font Family=path.ttf` instead of DomPDF's font directory dance.
+```php
+use Dompdf\Dompdf;
 
-<Note>This guide is a stub — it covers the load-bearing differences. If your template hits something unlisted, the render-time warnings will name it; issues welcome on [GitHub](https://github.com/formepdf/forme/issues).</Note>
+$dompdf = new Dompdf();
+$dompdf->loadHtml($html);
+$dompdf->setPaper('A4');
+$dompdf->render();
+file_put_contents('invoice.pdf', $dompdf->output());
+```
+
+**After, option 1 — the CLI, called from PHP** (simplest; the binary is `npx @formepdf/html` or a global install):
+
+```php
+file_put_contents('/tmp/invoice.html', $html);
+$exit = 0; $out = [];
+exec('forme-html /tmp/invoice.html -o /tmp/invoice.pdf 2>&1', $out, $exit);
+if ($exit !== 0) { throw new RuntimeException(implode("\n", $out)); }
+// stderr carried the warnings list — log it; it names anything outside the subset
+```
+
+**After, option 2 — a tiny Node service you own**, called from PHP over HTTP. The whole service:
+
+```js
+// service.mjs — node service.mjs (or PM2/systemd it)
+import { createServer } from 'node:http';
+import { renderHtml } from '@formepdf/html';
+
+createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    const { pdf, warnings } = renderHtml(body, {});
+    res.setHeader('content-type', 'application/pdf');
+    res.setHeader('x-forme-warnings', JSON.stringify(warnings));
+    res.end(Buffer.from(pdf));
+  });
+}).listen(3000);
+```
+
+```php
+$ch = curl_init('http://localhost:3000/');
+curl_setopt_array($ch, [
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => $html,
+    CURLOPT_RETURNTRANSFER => true,
+]);
+$pdf = curl_exec($ch);
+```
+
+This gets you the warnings as structured data rather than stderr, which matters once you automate the check in the next section.
+
+The HTML itself — the part you actually maintain — is what carries over.
+
+## Verifying the whole template set
+
+The real fear is not "will one invoice render" — it is "will I silently break every invoice for one customer segment." That is a structural question, and [pdf-testkit](https://github.com/danmolitor/pdf-testkit) answers it by diffing PDFs structurally, not by pixels:
+
+```bash
+npm i -g @pdf-testkit/cli && npm i -D pdfjs-dist
+
+# 1. Baseline what DomPDF produces today, per template
+pdf-testkit snapshot dompdf-output.pdf --out baseline.json
+
+# 2. Render the same HTML with Forme
+npx @formepdf/html invoice.html -o forme-output.pdf
+
+# 3. Structural diff — exit 0 clean, exit 1 regression
+pdf-testkit diff baseline.json forme-output.pdf --fail-on warn
+```
+
+Pixel diffing cannot do this across renderers: two engines rasterize the same document with different fonts hinting, different anti-aliasing, different rounding, so every page differs benignly and the diff is all noise. Structural comparison checks what matters — the text is all present, in order, on the right pages, in roughly the right places — and reports semantic events with confidence scores. Loop it over the template set and you get a short list of documents worth opening, instead of all of them.
+
+## The measured number
+
+Of 15 production templates collected from GitHub for our compat corpus — two of them stock Crater designs written specifically for DomPDF — **14 render correctly at 0.20.0, 1 degrades legibly with its cause named in warnings, 0 render broken** ([how it was measured](https://formepdf.com/blog/template-compat-endgame)). The two DomPDF-native templates are in the 14.
+
+## Who should migrate, and who shouldn't
+
+**Migrate** if PDF generation is a service boundary you can draw — a CLI call, a container, a small endpoint — and your pain is layout (flexbox), text (UTF-8/RTL), or print CSS. The templates come with you.
+
+**Don't migrate** if in-process PHP is a hard requirement. That constraint is legitimate and this library does not meet it.
+
+**What to try first:** `npx @formepdf/html your-template.html -o out.pdf` against your gnarliest real template, then read the warnings. One minute, and you will know which page of this guide matters to you. If something renders wrong without a warning naming it, [file it](https://github.com/formepdf/forme/issues) — that is a bug on our side by contract.

--- a/docs/guides/migrating-from-wkhtmltopdf.mdx
+++ b/docs/guides/migrating-from-wkhtmltopdf.mdx
@@ -1,10 +1,20 @@
 ---
 title: Migrating from wkhtmltopdf
 sidebarTitle: From wkhtmltopdf
-description: Move wkhtmltopdf templates to Forme's HTML input path — the legacy page-break-* spellings work as-is, with no abandoned WebKit binary.
+description: Move wkhtmltopdf templates to Forme's HTML input path — the legacy page-break-* spellings work as-is, the fixed-footer idiom works, and there is a way to verify 400 templates without opening 400 PDFs.
 ---
 
-wkhtmltopdf is unmaintained and pinned to a 2012-era WebKit. Forme's [HTML input path](/html) renders the same class of documents — invoices, reports, statements — through an actively maintained Rust/WASM engine, with no native binary to install.
+wkhtmltopdf renders the same class of documents Forme does — invoices, reports, statements. If it still works for you, nothing here says you must move. This guide is for when it stops working, and for verifying the move without trusting your eyes.
+
+## Why people leave wkhtmltopdf
+
+Three reasons come up, none of them about features you are missing today:
+
+1. **The project is archived.** Development ended and the GitHub repository was archived in 2023. There will be no more releases.
+2. **Open CVEs will stay open.** Known vulnerabilities (for example CVE-2022-35583, an SSRF in how it fetches resources) have no patch coming, because nothing is coming. If you feed it any user-influenced HTML, that is your problem to mitigate now.
+3. **The engine is a patched QtWebKit from the early 2010s.** It predates flexbox as you know it, CSS grid, and a decade of CSS. Every layout trick in a wkhtmltopdf template is a workaround for that engine, which is why the templates look the way they do.
+
+Forme's [HTML input path](/html) renders the same documents through an actively maintained Rust/WASM engine — no native binary to install, and the performance is [measured and published per commit](https://parity.formepdf.com/#benchmarks), not asserted.
 
 ## The short version
 
@@ -16,20 +26,82 @@ wkhtmltopdf invoice.html invoice.pdf
 npx @formepdf/html invoice.html -o invoice.pdf
 ```
 
-Three things make this migration gentler than you'd expect:
+Run it once and read the warnings list. Everything your template uses that Forme's subset doesn't cover is named there — that list is your migration checklist, and an empty list means you are done.
 
-1. **The legacy `page-break-*` spellings work.** wkhtmltopdf-era CSS (`page-break-before`, `page-break-after`, `page-break-inside: avoid`) is honored as-is alongside the modern `break-*` forms.
+## What moves over unchanged
+
+The wkhtmltopdf-era CSS dialect is, deliberately, well inside Forme's subset:
+
+1. **The legacy `page-break-*` spellings work.** `page-break-before`, `page-break-after`, `page-break-inside: avoid` are honored as-is, alongside the modern `break-*` forms.
 2. **`<thead>` repetition is automatic** — the header-rows-on-every-page behavior wkhtmltopdf approximated is engine-native here.
-3. **Floats lay out as columns.** The wkhtmltopdf-era float layouts (left/right header pairs, floated column grids) render as real columns; the one unsupported case is text wrapping *alongside* a float, which warns and renders below.
-4. **Anything outside the subset warns by name** instead of rendering differently in silence. Run your template once and read the warnings list — that's your migration checklist.
+3. **Floats lay out as columns.** The wkhtmltopdf-era float layouts (left/right header pairs, floated column grids) render as real columns.
+4. **The cascade, as written.** Type/class/id selectors, compounds, descendant and child combinators, attribute selectors (`[class*="col"]` and friends), `!important` — the stylesheet applies the way it applies in a browser. The [selector table](/html) lists the whole set.
+5. **`@page` and real running headers/footers** — see the next section, because this is where the flags go.
 
-The claim is measured: of 15 production templates in our compat corpus — several from the wkhtmltopdf/mPDF era, custom pagination hacks included — **14 render correctly at 0.20.0, 1 degrades legibly with its cause named in warnings, 0 broken** ([how it was measured](https://formepdf.com/blog/template-compat-endgame)).
+Concretely, this is a working Forme stylesheet, and every line of it is CSS you already know:
 
-## What to check
+```css
+@page {
+  size: A4;
+  margin: 72pt 54pt;
+  @top-center { content: "ACME WIDGET CO."; }
+  @bottom-right { content: "Page " counter(page) " of " counter(pages); }
+}
+h2 { page-break-before: always; }   /* the old spelling, honored */
+tr { page-break-inside: avoid; }
+.col-left  { float: left;  width: 48%; }
+.col-right { float: right; width: 48%; }
+```
 
-- **Headers/footers**: wkhtmltopdf's `--header-html`/`--footer-html` flags become `@page` margin boxes with `counter(page)` / `counter(pages)` — see [HTML Input → Paged media](/html).
-- **The `position: fixed` footer pattern works, with these semantics**: `#footer { position: fixed; bottom: 0 }` sits flush at the bottom of the page it occurs on — fixed anchors like absolute, because a paged renderer's viewport is the page. It does **not** repeat on every page the way wkhtmltopdf repeated it; for a footer on every page, use an `@page` margin box (that's what they're for). A render-time warning names this difference whenever `position: fixed` appears.
-- **Remote assets**: Forme never fetches over the network. Inline images as data URIs or local files; pass stylesheets with `--css`.
-- **Fonts**: system-font dependence becomes explicit — pass TTFs with `--font Family=path.ttf`.
+## Replacing the flags
 
-<Note>This guide is a stub — it covers the load-bearing differences. If your template hits something unlisted, the render-time warnings will name it; issues welcome on [GitHub](https://github.com/formepdf/forme/issues).</Note>
+Most of wkhtmltopdf's command-line surface was compensating for missing print CSS. The replacements are CSS:
+
+| wkhtmltopdf | Forme |
+|---|---|
+| `--header-html header.html` | `@page { @top-center { content: ... } }` margin boxes |
+| `--footer-center "Page [page] of [topage]"` | `@bottom-center { content: "Page " counter(page) " of " counter(pages) }` |
+| `--margin-top 20mm` etc. | `@page { margin: 20mm ... }` (or `--margin` on the CLI) |
+| `-s Letter` / `--page-size` | `@page { size: Letter }` (or `--page-size` on the CLI) |
+| `--disable-javascript` | The default and only mode — see below |
+
+And the one idiom nearly every wkhtmltopdf template carries: **the `position: fixed` footer works, with these semantics.** `#footer { position: fixed; bottom: 0 }` sits flush at the bottom of the page it occurs on — fixed anchors like absolute, because a paged renderer's viewport is the page. It does **not** repeat on every page the way wkhtmltopdf repeated it; for a footer on every page, use an `@page` margin box (that is what they are for). A render-time warning names this difference whenever `position: fixed` appears.
+
+## What doesn't move, up front
+
+- **JavaScript never executes.** wkhtmltopdf ran page scripts (slowly, in an old engine); Forme does not run them at all. If your template computes totals or builds rows in `<script>`, that logic moves into whatever generates the HTML.
+- **Nothing is fetched over the network.** Remote images, stylesheets, and `@font-face` URLs are never downloaded. Inline images as data URIs or local files; pass stylesheets with `--css`; pass fonts with `--font Family=path.ttf`. System-font dependence becomes explicit instead of environmental.
+- **Text does not wrap alongside a float.** Floated siblings lay out as columns — which is what invoice templates actually use floats for — but a paragraph flowing around a floated image renders below it instead, with a warning. This is the one float behavior that is out, and it is much narrower than it used to be.
+- **The named subset gaps.** Everything else outside the subset — transforms, gradients, CSS variables, `position: sticky` — warns by name at render time rather than rendering differently in silence. The [full subset table](/html) is the reference.
+
+## Verifying 400 templates without opening 400 PDFs
+
+The real fear in this migration is not "will one document render" — you can look at one document. It is "will I silently break 400 of them." That is a structural question, and there is tooling for it: [pdf-testkit](https://github.com/danmolitor/pdf-testkit) diffs PDFs by structure, not pixels.
+
+```bash
+npm i -g @pdf-testkit/cli && npm i -D pdfjs-dist
+
+# 1. Baseline the OLD renderer's output, once per template
+wkhtmltopdf invoice.html old.pdf
+pdf-testkit snapshot old.pdf --out baseline.json
+
+# 2. Render with Forme
+npx @formepdf/html invoice.html -o new.pdf
+
+# 3. Diff structurally — exit 0 clean, exit 1 regression
+pdf-testkit diff baseline.json new.pdf --fail-on warn
+```
+
+Why not just pixel-diff the two PDFs? Because two different renderers rasterize differently everywhere — different font engines, different anti-aliasing, different sub-pixel rounding — so a pixel diff lights up on every page whether or not anything is wrong, and you are back to eyeballing. Structural comparison asks the questions you actually care about: is the text all present, in the same reading order, on the same pages, in roughly the same places. It reports semantic events ("element moved", "text missing") with confidence scores instead of a red overlay, so a loop over 400 templates gives you a short list of the ones worth opening.
+
+## The measured number
+
+This claim is measured, not promised: of 15 production templates collected from GitHub for our compat corpus — several from the wkhtmltopdf/mPDF era, custom pagination hacks included — **14 render correctly at 0.20.0, 1 degrades legibly with its cause named in warnings, 0 render broken** ([how it was measured](https://formepdf.com/blog/template-compat-endgame)). For a template population like yours, that number is the most relevant fact on this page.
+
+## Who should migrate, and who shouldn't
+
+**Migrate** if your templates are documents — invoices, statements, reports, contracts — in the CSS dialect wkhtmltopdf shaped. That is the population the subset was built against, and the corpus number above is what happened when 15 of them met it cold.
+
+**Don't migrate yet** if your templates depend on in-page JavaScript to build their content, or fetch resources at render time you cannot inline. Move that logic out first, or stay put until you can.
+
+**What to try first:** one real template, one command, read the warnings. `npx @formepdf/html your-worst-template.html -o out.pdf` costs a minute and tells you more than this page can. If something renders wrong without a warning naming it, that is a bug on our side — [file it](https://github.com/formepdf/forme/issues).

--- a/docs/replacing-puppeteer.mdx
+++ b/docs/replacing-puppeteer.mdx
@@ -18,7 +18,24 @@ If you are using Puppeteer (or Playwright) to generate PDFs from HTML, you have 
 
 **Docker images are huge.** Chromium adds 400MB+ to your container. Forme has no native dependencies, so your image stays the size of your Node.js base.
 
+**Fonts differ between your laptop and the server.** Chrome falls back to whatever the OS provides, so the PDF that looked right locally ships with substituted fonts in the container. Forme never reads system fonts implicitly: you pass TTFs explicitly, and the same bytes render everywhere — [native and WASM output is byte-identical in CI](https://parity.formepdf.com).
+
 **Serverless cold starts are painful.** Chrome takes 3-10 seconds to start in Lambda or similar environments — and on many consumption tiers it cannot boot at all. Forme cold-starts in roughly 64ms on a Cloudflare Workers isolate and ~110ms on Node, measured at 0.20.0 ([provenance](https://parity.formepdf.com/#benchmarks)); the 7.66 MB WASM module instantiates in 1-10ms; the rest is first-render warmup.
+
+## You may not need to rewrite anything
+
+If your Puppeteer setup renders **HTML you already have**, the shortest migration is not JSX — it is the [HTML input path](/html):
+
+```js
+import { renderHtml } from '@formepdf/html';
+
+const { pdf, warnings } = renderHtml(html, {});
+// warnings names everything outside the documented subset — read it once
+```
+
+That is the whole replacement for `launch` / `newPage` / `setContent` / `page.pdf` / `close`: one synchronous call, no browser, and a warnings list that tells you exactly which parts of your CSS the subset does not cover. Measured against 15 production templates collected from GitHub (Bootstrap grids, wkhtmltopdf-era tables, email HTML, modern CSS grid), **14 render correctly at 0.20.0, 1 degrades legibly with its cause named in warnings, 0 render broken** ([how it was measured](https://formepdf.com/blog/template-compat-endgame)).
+
+The rest of this page shows the JSX path, which is the better end state when you control the template: typed components, no string templating, and the same engine underneath.
 
 ## The Puppeteer pipeline
 
@@ -193,15 +210,15 @@ Remove any Chromium-related Dockerfile steps, browser pool management code, and 
 
 Forme is not a drop-in replacement for every Puppeteer use case. Keep Puppeteer if:
 
-1. **You are rendering existing HTML/CSS you do not control.** If you receive HTML from a CMS, email template system, or third-party API and need to convert it to PDF, Puppeteer renders arbitrary HTML. Forme requires you to rewrite the template in JSX.
+1. **You are rendering an app, not a document.** A dashboard screenshot, a page that assembles itself in JavaScript, arbitrary third-party HTML of unknown shape — that is a browser's job. Forme renders documents: HTML you (or your template author) wrote, through a [documented CSS subset](/html) that warns by name on everything outside it. If you cannot enumerate what CSS your input uses, keep the browser.
 
-2. **You need full CSS support.** Forme supports a subset of CSS (flexbox, positioning, typography, borders, backgrounds). If your templates rely on CSS Grid, CSS animations, or other advanced CSS features, Puppeteer handles all of them.
+2. **You depend on page JavaScript.** If scripts build the DOM before printing — charting libraries, client-side templating, dynamic calculations — Puppeteer executes them and Forme never will. Move that logic out of the page first, or stay.
+
+   (Two reasons that *used* to be on this list are gone: existing HTML no longer requires a JSX rewrite — see the HTML input path above — and CSS Grid is now a supported subset, not an exclusion.)
 
 3. **You need complex SVG rendering.** Forme supports basic SVG elements (`rect`, `circle`, `ellipse`, `line`, `polyline`, `polygon`, `path`), but not advanced SVG features like filters, gradients, masks, or CSS styling within SVG. If your PDFs contain complex charts from D3 or Chart.js, Puppeteer may still handle more of the SVG spec.
 
-4. **You need JavaScript execution.** If your template includes client-side JavaScript that modifies the DOM before rendering (e.g., charting libraries, dynamic calculations), Puppeteer executes it. Forme templates are static at render time.
-
-5. **You need screenshots, not PDFs.** Puppeteer captures screenshots of web pages. Forme only produces PDFs.
+4. **You need screenshots, not PDFs.** Puppeteer captures screenshots of web pages. Forme only produces PDFs.
 
 ## Common patterns
 
@@ -243,3 +260,32 @@ Header rows repeat on every page, guaranteed.
 ```
 
 Full styling control over the page number element.
+
+## Verifying the migration across your whole template set
+
+The real fear is not "will one document render" — it is "will I silently break 400 of them." That is a structural question, and [pdf-testkit](https://github.com/danmolitor/pdf-testkit) answers it by diffing PDFs structurally rather than by pixels:
+
+```bash
+npm i -g @pdf-testkit/cli && npm i -D pdfjs-dist
+
+# 1. Baseline what Puppeteer produces today, per template
+pdf-testkit snapshot puppeteer-output.pdf --out baseline.json
+
+# 2. Render the same document with Forme (either path)
+npx @formepdf/html invoice.html -o forme-output.pdf
+
+# 3. Structural diff — exit 0 clean, exit 1 regression
+pdf-testkit diff baseline.json forme-output.pdf --fail-on warn
+```
+
+Pixel diffing cannot do this across renderers. Chrome and Forme rasterize with different font engines, different anti-aliasing, different sub-pixel rounding — every page differs benignly, the diff is all noise, and you are back to opening PDFs by hand. Structural comparison checks what you actually care about: all the text is present, in the same reading order, on the same pages, in roughly the same places. It reports semantic events with confidence scores, so a loop over the whole template set produces a short list of documents worth opening instead of all of them.
+
+Once migrated, keep the same tool as your regression gate: `toMatchPDFSnapshot()` in Vitest or Jest baselines every template, and with Forme's `LayoutInfo` fast path it skips PDF parsing entirely.
+
+## The honest close
+
+**Migrate** if you are generating documents — invoices, statements, reports — from HTML or templates you control, and the browser is pure overhead: cold starts, memory, a binary to babysit, fonts that differ by environment.
+
+**Don't migrate** if you are rendering an app rather than a document, or your pages need their JavaScript to exist. Those are browser jobs and Puppeteer is good at them.
+
+**What to try first:** one real template, one command — `npx @formepdf/html your-template.html -o out.pdf` — and read the warnings. It costs a minute and tells you which of the sections above apply to you. Every performance number on this page is measured per commit and published with provenance at [parity.formepdf.com](https://parity.formepdf.com); if something renders wrong without a warning naming it, [file it](https://github.com/formepdf/forme/issues) — that is a bug on our side by contract.


### PR DESCRIPTION
The SEO backbone was two stubs plus one real page with stale exclusions. All three guides now carry the full structure: why people leave (concrete, no strawmanning), what moves over unchanged with real CSS, what doesn't up front (float caveat stated at its current narrow width), before/after code, the pdf-testkit structural-verification recipe with the why-pixel-diffing-fails explanation, the measured 14/1/0 corpus number with a link to the write-up, and an honest who-should/shouldn't close.

Notable:
- **DomPDF** opens with the PHP→JavaScript reality rather than burying it, and offers two honest paths (CLI from PHP; a 15-line Node sidecar). During writing, two inherited claims failed verification and were removed: the self-hosted server has no HTML render endpoint (`server/src/routes` checked), and the Python/Go SDKs carry no HTML path.
- **Puppeteer** had two stale exclusions: "requires a JSX rewrite" (renderHtml has existed since 0.14) and "CSS Grid → keep Puppeteer" (grid subset since 0.17). Replaced with the real boundary: rendering an app vs a document, and page JavaScript. Fonts-differ-between-laptop-and-server added to the problems list.
- **wkhtmltopdf** gains the why-leave section (archived 2023, CVE-2022-35583 unpatched, QtWebKit era), a flag→CSS replacement table, and keeps the `position: fixed` footer semantics note.

Every number on the pages is one already published and sourced (corpus baselines, parity artifact, registry-measured sizes); no new figures were introduced.