### PR TITLE
CI: upload rendered documents to Forme Review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,20 @@ jobs:
         # Needed for the worker (vitest-pool-workers) and browser (playwright)
         # checks below; the parity loop above uses only the Node target.
         run: npm install
+      # Forme Review: upload the documents the tests just rendered. The first
+      # upload establishes each document's baseline; every PR after that is
+      # compared and reported as a check and a comment. Structure only by
+      # default; the service never receives the PDF itself.
+      - uses: danmolitor/pdf-testkit/packages/action@v0.2.2
+        with:
+          service-token: ${{ secrets.PDF_TESTKIT_TOKEN }}
+          service-url: https://review-api.formepdf.com
+          documents: |
+            html/target/letterhead.pdf
+            html/target/report.pdf
+            html/target/statement.pdf
+            html/target/zebra-invoice.pdf
+            html/target/spike-invoice.pdf
       - name: HTML Node tests
         working-directory: packages/html
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         # First upload establishes each template's baseline; every PR after
         # that is compared and reported as a check and a comment. Structure
         # only by default; nothing rendered leaves the runner.
-        uses: danmolitor/pdf-testkit/packages/action@v0.2.2
+        uses: danmolitor/pdf-testkit/packages/action@v0.2.3
         with:
           service-token: ${{ secrets.PDF_TESTKIT_TOKEN }}
           service-url: https://review-api.formepdf.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,19 +82,6 @@ jobs:
         # Needed for the worker (vitest-pool-workers) and browser (playwright)
         # checks below; the parity loop above uses only the Node target.
         run: npm install
-      # Forme Review: upload the documents the tests just rendered. The first
-      # upload establishes each document's baseline; every PR after that is
-      # compared and reported as a check and a comment. Structure only by
-      # default; the service never receives the PDF itself.
-      - uses: danmolitor/pdf-testkit/packages/action@v0.2.2
-        with:
-          service-token: ${{ secrets.PDF_TESTKIT_TOKEN }}
-          service-url: https://review-api.formepdf.com
-          documents: |
-            html/target/report.pdf
-            html/target/statement.pdf
-            html/target/zebra-invoice.pdf
-            html/target/spike-invoice.pdf
       - name: HTML Node tests
         working-directory: packages/html
         run: npm test
@@ -285,6 +272,31 @@ jobs:
         with:
           name: invoice-layout
           path: packages/core/invoice-layout.json
+      - name: Render template layouts for Forme Review
+        # The engine's own LayoutInfo for every shipped template, which the
+        # pdf-testkit CLI converts to a structural snapshot without touching a
+        # PDF. One batch per commit: the service judges document presence when
+        # the batch completes, so every document goes up from this one step.
+        working-directory: packages/core
+        run: |
+          mkdir -p ../../dist/templates
+          for t in invoice receipt report letter shipping-label; do
+            node scripts/render-template-layout.mjs "$t" "../../dist/templates/$t.json"
+          done
+      - name: Upload to Forme Review
+        # First upload establishes each template's baseline; every PR after
+        # that is compared and reported as a check and a comment. Structure
+        # only by default; nothing rendered leaves the runner.
+        uses: danmolitor/pdf-testkit/packages/action@v0.2.2
+        with:
+          service-token: ${{ secrets.PDF_TESTKIT_TOKEN }}
+          service-url: https://review-api.formepdf.com
+          documents: |
+            dist/templates/invoice.json
+            dist/templates/receipt.json
+            dist/templates/report.json
+            dist/templates/letter.json
+            dist/templates/shipping-label.json
       - name: Test React
         working-directory: packages/react
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
           service-token: ${{ secrets.PDF_TESTKIT_TOKEN }}
           service-url: https://review-api.formepdf.com
           documents: |
-            html/target/letterhead.pdf
             html/target/report.pdf
             html/target/statement.pdf
             html/target/zebra-invoice.pdf

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@pdf-testkit/cli": "^0.2.2",
+        "@pdf-testkit/cli": "^0.2.3",
         "miniflare": "4.20260730.0",
-        "pdfjs-dist": "^4.10.38",
         "puppeteer-core": "25.10.0"
       }
     },
@@ -2151,25 +2150,26 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/cli": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.2.2.tgz",
-      "integrity": "sha512-AcJA5NomhKBsQWhRIP6Dyi7XfZ10BOB69m7Bc83BHLYCWGMwph0pwx6xRCF1UHVusbDPfnuEiw4I8PIWic9mFw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.2.3.tgz",
+      "integrity": "sha512-t0jdpjfbPpW2SrNVp7fNJ4m3rDAzWymq+op/Di5TN+JERrdAIMdHfq4R3ZYgY7Tk2UvaKAqaFIf7Lq4GRb/Rcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.2.2",
-        "@pdf-testkit/matcher-core": "^0.2.2",
-        "@pdf-testkit/protocol": "^0.2.2",
-        "commander": "^12.1.0"
+        "@pdf-testkit/core": "^0.2.3",
+        "@pdf-testkit/matcher-core": "^0.2.3",
+        "@pdf-testkit/protocol": "^0.2.3",
+        "commander": "^12.1.0",
+        "pdfjs-dist": "^4.10.38"
       },
       "bin": {
         "pdf-testkit": "bin/pdf-testkit.js"
       }
     },
     "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/core": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.2.2.tgz",
-      "integrity": "sha512-tDXScEz3uw2/mRrNcLagjlPT2oDXgY30hplEyA9HmVylhgjzZCJdOfubncbWcRSXZymLaI2ymDeCAxh9zAOt/A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.2.3.tgz",
+      "integrity": "sha512-6RMFKqSHVCSspfjrWXPPbBmeNjEz9WlWaDJjTVYcdMyrU0aaUeHl2vbgZQL1xmJmQ6lCwKU1nB3xHI5UVvx2TQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2186,13 +2186,13 @@
       }
     },
     "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.2.2.tgz",
-      "integrity": "sha512-jzEl4x/bvc2EVgJdD6hvqMrMCJAAsDjjrEnM1oVXgVbFxZN3PqtgbRPunVDpsaUMIR/New8Rzt4u3HJ0gZBhDA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.2.3.tgz",
+      "integrity": "sha512-s2V8Hgri90YoyPBAl7Ens0bzYeHtk2jlYw6MEti0IDOteaVS5rXBUWDxtlFbn0gKdktiuYwBPIV4PPI8os9MyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.2.2"
+        "@pdf-testkit/core": "^0.2.3"
       }
     },
     "node_modules/@pdf-testkit/core": {
@@ -2221,9 +2221,9 @@
       }
     },
     "node_modules/@pdf-testkit/protocol": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.2.2.tgz",
-      "integrity": "sha512-vlQ9CjbZd+aA5Kcj+jIc43Jg5WaGbW935l8G4YEvDFvUUkWd3srbPk+GDo3lnmnmtSCTSxVdfudx/eX+qdkvmg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.2.3.tgz",
+      "integrity": "sha512-x5MOb1FjxO1Drb8eUmJTpHuvN7gUTkn7KzWK/d2FqRl9fEXnDi4ubO21Z//nd5vMDWR5JoWq9lBodVVru8IIZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "forme",
+  "name": "forme-wt",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,6 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@pdf-testkit/cli": "^0.2.2",
         "miniflare": "4.20260730.0",
         "puppeteer-core": "25.10.0"
       }
@@ -1886,6 +1887,51 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@pdf-testkit/cli": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.2.2.tgz",
+      "integrity": "sha512-AcJA5NomhKBsQWhRIP6Dyi7XfZ10BOB69m7Bc83BHLYCWGMwph0pwx6xRCF1UHVusbDPfnuEiw4I8PIWic9mFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-testkit/core": "^0.2.2",
+        "@pdf-testkit/matcher-core": "^0.2.2",
+        "@pdf-testkit/protocol": "^0.2.2",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "pdf-testkit": "bin/pdf-testkit.js"
+      }
+    },
+    "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/core": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.2.2.tgz",
+      "integrity": "sha512-tDXScEz3uw2/mRrNcLagjlPT2oDXgY30hplEyA9HmVylhgjzZCJdOfubncbWcRSXZymLaI2ymDeCAxh9zAOt/A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.65",
+        "pdfjs-dist": "^4.10 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        },
+        "pdfjs-dist": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/matcher-core": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.2.2.tgz",
+      "integrity": "sha512-jzEl4x/bvc2EVgJdD6hvqMrMCJAAsDjjrEnM1oVXgVbFxZN3PqtgbRPunVDpsaUMIR/New8Rzt4u3HJ0gZBhDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-testkit/core": "^0.2.2"
+      }
+    },
     "node_modules/@pdf-testkit/core": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.6.tgz",
@@ -1909,6 +1955,16 @@
       "license": "MIT",
       "dependencies": {
         "@pdf-testkit/core": "^0.1.6"
+      }
+    },
+    "node_modules/@pdf-testkit/protocol": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.2.2.tgz",
+      "integrity": "sha512-vlQ9CjbZd+aA5Kcj+jIc43Jg5WaGbW935l8G4YEvDFvUUkWd3srbPk+GDo3lnmnmtSCTSxVdfudx/eX+qdkvmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.25.0"
       }
     },
     "node_modules/@pdf-testkit/vitest": {
@@ -3277,6 +3333,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@pdf-testkit/cli": "^0.2.2",
         "miniflare": "4.20260730.0",
+        "pdfjs-dist": "^4.10.38",
         "puppeteer-core": "25.10.0"
       }
     },
@@ -1861,6 +1862,268 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -4821,6 +5084,19 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@pdf-testkit/cli": "^0.2.2",
     "miniflare": "4.20260730.0",
     "puppeteer-core": "25.10.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@pdf-testkit/cli": "^0.2.2",
+    "@pdf-testkit/cli": "^0.2.3",
     "miniflare": "4.20260730.0",
-    "pdfjs-dist": "^4.10.38",
     "puppeteer-core": "25.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@pdf-testkit/cli": "^0.2.2",
     "miniflare": "4.20260730.0",
+    "pdfjs-dist": "^4.10.38",
     "puppeteer-core": "25.10.0"
   }
 }


### PR DESCRIPTION
Adds the pdf-testkit Action in service mode after the HTML tests, uploading the five documents they render (letterhead, report, statement, zebra invoice, spike invoice) to Forme Review at review-api.formepdf.com. The first upload establishes each document's baseline; every PR after that is compared and reported as a check and a comment. Structure only by default; the service never receives the PDF itself.

Also adds `@pdf-testkit/cli` as a root dev dependency, which the Action runs.