### PR TITLE
Northmoor: body type one step up the scale

### DIFF
--- a/templates/northmoor-shared.css
+++ b/templates/northmoor-shared.css
@@ -26,8 +26,8 @@ body {
   margin: 0;
   background-color: #FDFCFA;
   font-family: Helvetica, Arial, sans-serif;
-  font-size: 7.5pt;      /* 10px prototype base */
-  line-height: 1.5;
+  font-size: 8.25pt;     /* 11px prototype base — one step up the scale */
+  line-height: 1.6;
   color: #111111;
 }
 


### PR DESCRIPTION
Base body size 7.5pt → 8.25pt and line-height 1.5 → 1.6 in `northmoor-shared.css`. Every Northmoor document reflows at once.

This is a workload test for Forme Review: one stylesheet change, thirty documents to review. Watching the check title, the comment's length, and whether approving is one decision or thirty.