### PR TITLE
Sequential-split defect: fire on the outcome, name the row

### DIFF
--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -2312,25 +2312,6 @@ impl LayoutEngine {
 
         cursor.continuation_top_offset = prev_continuation_offset;
 
-        // A flex ROW that splits across pages lays its children out
-        // sequentially (each into the space that remains), not as
-        // parallel columns continuing side by side on every page. For
-        // short rows the difference is invisible; for column layouts
-        // taller than a page it is a real divergence from the browser
-        // rendering — say so through the defect channel rather than
-        // degrading silently.
-        if pages.len() > initial_page_count
-            && node.children.len() > 1
-            && matches!(
-                style.flex_direction,
-                FlexDirection::Row | FlexDirection::RowReverse
-            )
-        {
-            self.defect(
-                "render defect: a flex row split across pages lays its children sequentially — columns taller than a page do not continue side by side".to_string(),
-            );
-        }
-
         // Check if this view has any visual styling worth wrapping
         let has_visual = style.background_color.is_some()
             || style.border_width.top > 0.0
@@ -3098,6 +3079,18 @@ impl LayoutEngine {
             let line_elem_start = cursor.elements.len();
             let mut x = content_x + start_offset;
 
+            // Sequential-split detection, precise form: the genuinely
+            // sequential outcome is an ITEM's own layout breaking the
+            // page while siblings share its line — the siblings don't
+            // continue beside it on the next page, so columns serialize.
+            // The signature is page growth DURING the item loop. A row
+            // that merely relocated whole broke in the line-fit check
+            // ABOVE, before this count is taken, and stays silent (the
+            // old check fired on any page growth during the row's whole
+            // layout and closed a correct PR — a warning that cries
+            // wolf is worse than none).
+            let line_start_pages = pages.len();
+
             for (j, item) in line_items.iter().enumerate() {
                 if j > 0 {
                     x += column_gap + between_extra;
@@ -3176,6 +3169,16 @@ impl LayoutEngine {
                 x += fw;
             }
 
+            if line_items.len() > 1 && pages.len() > line_start_pages {
+                let near = line_items
+                    .iter()
+                    .find_map(|it| first_text_snippet(it.node))
+                    .map(|t| format!(" (row beginning \"{t}\")"))
+                    .unwrap_or_default();
+                self.defect(format!(
+                    "render defect: a flex row crossing a page boundary lays its children sequentially — a column taller than the page does not continue side by side{near}"
+                ));
+            }
             cursor.y = row_start_y + line_height;
             line_infos.push((line_elem_start, cursor.elements.len(), line_height));
         }
@@ -7355,6 +7358,32 @@ struct FlexItem<'a> {
     style: ResolvedStyle,
     base_width: f64,
     min_content_width: f64,
+}
+
+/// First bit of text content under a node, for naming elements in
+/// render-defect messages (the engine's Node has no id/class).
+fn first_text_snippet(node: &Node) -> Option<String> {
+    fn walk(n: &Node) -> Option<&str> {
+        match &n.kind {
+            NodeKind::Text { content, runs, .. } | NodeKind::Heading { content, runs, .. } => {
+                if !content.trim().is_empty() {
+                    return Some(content.trim());
+                }
+                if let Some(r) = runs.iter().find(|r| !r.content.trim().is_empty()) {
+                    return Some(r.content.trim());
+                }
+                None
+            }
+            _ => n.children.iter().find_map(walk),
+        }
+    }
+    walk(node).map(|t| {
+        let mut s: String = t.chars().take(32).collect();
+        if t.chars().count() > 32 {
+            s.push('…');
+        }
+        s
+    })
 }
 
 #[cfg(test)]

--- a/html/tests/css_tables.rs
+++ b/html/tests/css_tables.rs
@@ -190,3 +190,59 @@ fn page_tall_column_row_reports_the_sequential_split_defect() {
         out.warnings
     );
 }
+
+#[test]
+fn row_that_relocates_whole_does_not_report_sequential_split() {
+    // The false positive that closed a correct PR: a short flex row pushed
+    // past a page boundary moves WHOLE to the next page — every child
+    // starts on the same page, side by side. The old warning fired on any
+    // page growth during the row's layout; the precise one must stay
+    // silent here.
+    let filler: String = (0..80).map(|i| format!("<p>line {i}</p>")).collect();
+    let html = format!(
+        "<html><body>{filler}\
+         <div style=\"display: flex\">\
+           <div style=\"width: 50%\"><p>left cell</p></div>\
+           <div style=\"width: 50%\"><p>right cell</p></div>\
+         </div></body></html>"
+    );
+    let out = render(&html);
+    assert!(
+        out.layout.pages.len() > 1,
+        "the row must actually be pushed across"
+    );
+    assert!(
+        !out.warnings.iter().any(|w| w.contains("sequentially")),
+        "a relocated-whole row is not a sequential split: {:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn sequential_split_defect_names_the_offending_row() {
+    // Diagnosing the false positive required rect-dumping because the
+    // deduped message carried no element identification. It now names the
+    // row by its first text content.
+    let tall: String = (0..120)
+        .map(|i| format!("<p>content line {i}</p>"))
+        .collect();
+    let html = format!(
+        "<html><head><style>.t {{ display: table }} .c {{ display: table-cell }}\
+         .a {{ width: 33% }} .b {{ width: 67% }}</style></head><body><div class=\"t\">\
+         <div class=\"c a\"><p>sidebar heading</p></div>\
+         <div class=\"c b\">{tall}</div>\
+         </div></body></html>"
+    );
+    let out = render(&html);
+    let defect = out.warnings.iter().find(|w| w.contains("sequentially"));
+    assert!(
+        defect.is_some(),
+        "true positive must still fire: {:?}",
+        out.warnings
+    );
+    assert!(
+        defect.unwrap().contains("sidebar heading"),
+        "the defect must name the row: {}",
+        defect.unwrap()
+    );
+}

--- a/templates/northmoor-shared.css
+++ b/templates/northmoor-shared.css
@@ -477,3 +477,7 @@ td.broughtlab { color: #767676; }
  * page fragment, so anchoring to .sheet painted the rule on the final
  * page of multi-page documents. */
 header { position: relative; }
+/* The design's own rule: signature blocks never split from the text they
+ * execute — and never split internally. (A signature row falling across a
+ * page boundary moves whole to the next page.) */
+.sig { break-inside: avoid; }


### PR DESCRIPTION
The sequential-split render defect fired on the *path* (breakable row layout grew the page list), which includes a short row relocating whole to the next page — a correct outcome. That false positive closed a correct PR (#68). The check now lives in `layout_flex_row`'s item loop and fires only when an item's own layout breaks the page while siblings share its flex line — the genuinely sequential outcome. The line-fit relocation check runs before the count is taken, so relocation stays silent.

The message now also names the offending row by its first text content, since diagnosing the false positive required rect-dumping precisely because the message identified nothing.

- Pins: relocated-whole row silent (failed before the fix); page-tall column row still warns, message names the row.
- Corpus 09 re-verified with a fresh release build: still fires, now as `row beginning "INVOICE"`.
- Template hygiene per the design's own rule: `.sig { break-inside: avoid }` in the Northmoor shared spine. Byte-identical at current scale.
- Gates: engine 322 + html 228 green, clippy `--all-targets -D warnings` both crates, byte-wall vs main IDENTICAL (6/6), 30-template determinism (node == web, warning-free), reconciling chains hold.
- Local re-render of policy-acknowledgement at #68's type scale: zero warnings.