### PR TITLE
Northmoor: break-inside on every signature container, gated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
         # target across the fixture corpus. The three targets embed the same
         # wasm (asserted by hash here); this proves the JS glue matches too.
         run: node packages/html/test/targets-determinism.mjs
+      - name: Northmoor signature hygiene (break-inside on sig containers)
+        # The design rule "signature blocks never split" as a gate — every
+        # signature container class used in template markup must resolve
+        # break-inside: avoid (it was applied to contracts and missed on
+        # letters, receipts, and the certificate).
+        run: node scripts/northmoor-sig-hygiene.mjs
       - name: HTML worker entry under workerd
         # Real Cloudflare WASM-as-ESM semantics via @cloudflare/vitest-pool-workers,
         # exactly as the core worker entry is gated. Catches the bundler-target

--- a/scripts/northmoor-sig-hygiene.mjs
+++ b/scripts/northmoor-sig-hygiene.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// The Northmoor design rule: signature blocks never split from the text
+// they execute — and never split internally. This gate asserts every
+// signature CONTAINER class actually used in template markup resolves
+// `break-inside: avoid` (from the shared spine or the template's own
+// css). The rule was applied to the batch-2 contracts (`.keep`) and
+// later to `.sig`, and missed on `.sigrow`, `.signoff`, and
+// `.cert-sigs` — hygiene that greps, not memory that hopes.
+// Run: node scripts/northmoor-sig-hygiene.mjs
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const T = join(dirname(fileURLToPath(import.meta.url)), '..', 'templates');
+
+// Signature container classes (the outermost block the design rule
+// protects). Inner pieces (.sigbox, .sigline, .sigcell, .cert-sig) are
+// carried by their container. `.keep` is the contracts' generic wrapper
+// and is asserted too — it exists solely to express this rule.
+const CONTAINERS = ['sig', 'sigrow', 'signoff', 'cert-sigs', 'keep'];
+
+const shared = readFileSync(join(T, 'northmoor-shared.css'), 'utf8');
+
+function hasAvoid(css, cls) {
+  // A rule whose selector list contains .cls (exact class token) and whose
+  // declaration block contains break-inside: avoid.
+  const re = /([^{}]+)\{([^}]*)\}/g;
+  for (const [, sel, body] of css.matchAll(re)) {
+    if (
+      new RegExp(`\\.${cls}(?![\\w-])`).test(sel) &&
+      /break-inside\s*:\s*avoid/.test(body)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+let failures = 0;
+for (const dir of readdirSync(T, { withFileTypes: true })) {
+  if (!dir.isDirectory()) continue;
+  const htmlPath = join(T, dir.name, 'index.html');
+  if (!existsSync(htmlPath)) continue;
+  const html = readFileSync(htmlPath, 'utf8');
+  const own = existsSync(join(T, dir.name, 'style.css'))
+    ? readFileSync(join(T, dir.name, 'style.css'), 'utf8')
+    : '';
+  for (const cls of CONTAINERS) {
+    if (!new RegExp(`class="[^"]*\\b${cls}(?![\\w-])`).test(html)) continue;
+    const ok = hasAvoid(shared, cls) || hasAvoid(own, cls);
+    if (!ok) failures++;
+    console.log(`${ok ? '  ok ' : 'FAIL'}  ${dir.name}: .${cls} carries break-inside: avoid`);
+  }
+}
+
+console.log(
+  failures
+    ? `\n${failures} signature container(s) missing break-inside: avoid`
+    : '\nAll signature containers carry break-inside: avoid.'
+);
+process.exit(failures ? 1 : 0);

--- a/templates/certificate/style.css
+++ b/templates/certificate/style.css
@@ -52,7 +52,7 @@
 }
 .cert-body { font-family: Georgia, 'Times New Roman', serif; font-size: 8.25pt; line-height: 1.85; margin-top: 16.5pt; max-width: 247.5pt; }
 .cert-meta { display: flex; gap: 25.5pt; margin-top: 22.5pt; text-align: left; font-size: 7.125pt; line-height: 1.6; justify-content: center; }
-.cert-sigs { display: flex; gap: 33pt; margin-top: 27pt; text-align: left; width: 100%; }
+.cert-sigs { display: flex; gap: 33pt; margin-top: 27pt; text-align: left; width: 100%; break-inside: avoid; }
 .cert-sig { flex-grow: 1; border-top: 0.75pt solid #111111; padding-top: 5.25pt; }
 .cert-sig-short { flex-grow: 0.7; }
 .cert-foot { margin-top: auto; display: flex; justify-content: space-between; align-items: flex-end; font-size: 6pt; letter-spacing: 0.11em; text-transform: uppercase; color: #767676; padding-top: 19.5pt; width: 100%; }

--- a/templates/northmoor-shared.css
+++ b/templates/northmoor-shared.css
@@ -479,5 +479,6 @@ td.broughtlab { color: #767676; }
 header { position: relative; }
 /* The design's own rule: signature blocks never split from the text they
  * execute — and never split internally. (A signature row falling across a
- * page boundary moves whole to the next page.) */
-.sig { break-inside: avoid; }
+ * page boundary moves whole to the next page.) Every signature CONTAINER
+ * class carries it; scripts/northmoor-sig-hygiene.mjs is the gate. */
+.sig, .sigrow, .signoff { break-inside: avoid; }


### PR DESCRIPTION
The design rule (signature blocks never split) was applied to the batch-2 contracts via `.keep` and later to `.sig` — and missed on `.sigrow` (receipt, expense-report, purchase-order, quote), `.signoff` (the five letters), and `.cert-sigs` (certificate): 10 misses across the thirty templates.

- Applied `break-inside: avoid` to all three containers (shared spine + certificate's local css).
- The audit became a gate: `scripts/northmoor-sig-hygiene.mjs` asserts every signature container class used in template markup resolves `break-inside: avoid`. Fails-first: reported the 10 misses before the css change. Wired into CI beside the determinism gate.
- Byte-identical at current scale, verified per affected template (before/after render comparison, 10/10 IDENTICAL — nothing splits today; the rule protects future edits).
- Gates: 30/30 node==web determinism warning-free, reconciling chains hold.