### PR TITLE
Absolute children anchor to the first fragment of a split containing block

### DIFF
--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -2474,6 +2474,10 @@ impl LayoutEngine {
         // Save parent content box position for absolute children
         let parent_box_y = cursor.content_y + cursor.y;
         let parent_box_x = content_x;
+        // The page the parent box STARTS on. When flow layout breaks pages,
+        // absolute children must anchor to (and render on) this FIRST
+        // fragment per CSS — parent_box_x/y are coordinates on this page.
+        let entry_page_index = pages.len();
 
         // If this container is *explicitly* positioned it becomes the
         // containing block for its absolute descendants. Update the cursor's
@@ -2805,6 +2809,15 @@ impl LayoutEngine {
         // nearest positioned ancestor / page carried on the cursor. This is the
         // v0-divergence retirement — an absolute inside an *unpositioned* parent
         // now escapes to its nearest positioned ancestor, matching browsers.
+        // Did the parent fragment across pages during flow layout? Its
+        // absolutes then anchor to the FIRST fragment (CSS): coordinates
+        // are already first-page coordinates (parent_box_x/y), the auto
+        // height is the first fragment's extent (down to that page's
+        // content bottom — the fragment ran to the page end), and the
+        // elements are emitted onto that page rather than the post-break
+        // cursor. Emitting into the cursor was the last-fragment bug: the
+        // badge drawn from first-page coordinates landed on the last page.
+        let parent_fragmented = parent_positioned && pages.len() > entry_page_index;
         let (cb_x, cb_y, cb_w, cb_h) = if parent_positioned {
             let ph = parent_style
                 .and_then(|ps| match ps.height {
@@ -2813,7 +2826,14 @@ impl LayoutEngine {
                     }
                     SizeConstraint::Auto => None,
                 })
-                .unwrap_or(cursor.content_y + cursor.y - parent_box_y);
+                .unwrap_or_else(|| {
+                    if parent_fragmented {
+                        let first = &pages[entry_page_index];
+                        (first.height - first.config.margin.bottom) - parent_box_y
+                    } else {
+                        cursor.content_y + cursor.y - parent_box_y
+                    }
+                });
             (parent_box_x, parent_box_y, available_width, ph)
         } else {
             cursor.containing_block
@@ -2885,8 +2905,14 @@ impl LayoutEngine {
                 None,
             );
 
-            // Add absolute elements to the current cursor (renders on top)
-            cursor.elements.extend(abs_cursor.elements);
+            // Add absolute elements to the page the containing block starts
+            // on: the finalized first fragment when the parent broke across
+            // pages, else the current cursor (renders on top either way).
+            if parent_fragmented {
+                pages[entry_page_index].elements.extend(abs_cursor.elements);
+            } else {
+                cursor.elements.extend(abs_cursor.elements);
+            }
         }
 
         // Restore the containing block for the caller's remaining siblings.

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -12444,3 +12444,57 @@ fn border_or_background_on_text_node_reports_render_defect() {
         "background defect must be reported: {warnings:?}"
     );
 }
+
+#[test]
+fn absolute_child_anchors_to_the_first_fragment_of_a_split_parent() {
+    // CSS conformance: an absolutely positioned element anchors to its
+    // containing block's FIRST fragment when the block spans pages. It
+    // anchored to the LAST fragment (the absolute pass emitted into the
+    // post-break cursor while cb coordinates came from the first page) —
+    // the parked finding that made the Northmoor templates move page-1
+    // furniture into <header>.
+    let filler = r#"
+        { "kind": { "type": "Text", "content": "A" }, "style": {}, "children": [] },
+        { "kind": { "type": "View" }, "style": { "height": { "Pt": 700 } }, "children": [] },
+        { "kind": { "type": "Text", "content": "B" }, "style": {}, "children": [] },
+        { "kind": { "type": "View" }, "style": { "height": { "Pt": 700 } }, "children": [] },
+        { "kind": { "type": "Text", "content": "C" }, "style": {}, "children": [] }
+    "#;
+    let json = format!(
+        r#"{{
+        "children": [
+            {{ "kind": {{ "type": "View" }}, "style": {{ "position": "Relative" }},
+               "children": [
+                    {{ "kind": {{ "type": "View" }},
+                       "style": {{ "position": "Absolute", "top": 0, "left": 0, "width": {{ "Pt": 80 }} }},
+                       "children": [ {{ "kind": {{ "type": "Text", "content": "anchor badge" }}, "style": {{}}, "children": [] }} ] }},
+                    {filler}
+               ] }}
+        ],
+        "metadata": {{}}
+    }}"#
+    );
+    let (_pdf, layout, _warnings) =
+        forme::render_json_with_layout(&json).expect("split positioned parent renders");
+    fn page_of(layout: &forme::layout::LayoutInfo, needle: &str) -> Option<usize> {
+        fn has(els: &[forme::layout::ElementInfo], needle: &str) -> bool {
+            els.iter().any(|e| {
+                e.text_content
+                    .as_deref()
+                    .is_some_and(|t| t.contains(needle))
+                    || has(&e.children, needle)
+            })
+        }
+        layout.pages.iter().position(|p| has(&p.elements, needle))
+    }
+    assert!(
+        layout.pages.len() > 1,
+        "the positioned parent must span pages, got {}",
+        layout.pages.len()
+    );
+    assert_eq!(
+        page_of(&layout, "anchor badge"),
+        Some(0),
+        "top-anchored absolute belongs to the FIRST fragment"
+    );
+}


### PR DESCRIPTION
CSS conformance fix for the parked finding: when a positioned parent fragments across pages, absolutely positioned children anchored to the LAST fragment — the absolute pass emitted into the post-break cursor while containing-block coordinates came from the first page. This is what made the Northmoor templates move page-1 furniture into `<header>`.

**Diagnosis (local, not structural):** single emission point in `layout_children`'s second pass. The fix routes absolute elements onto the finalized first-fragment page when pages grew during the parent's flow layout, and makes the auto containing-block height the first fragment's extent (previously last-page cursor minus first-page origin — incoherent across pages). The escape-to-ancestor case is unaffected: `new_page()` resets `containing_block` to the fresh page's box, so that CB is always on the current page (its CB-loss-on-break divergence is a separate, still-open finding, noted in the commit).

**Pin (failed before the fix):** split `position: relative` parent + `top: 0` absolute child — badge landed on page 1, must be page 0.

**Blast radius, surveyed before landing:** byte-wall 6/6 IDENTICAL, template-compat corpus 15/15 IDENTICAL, all 30 Northmoor templates IDENTICAL (main-built binary vs fix-built binary), all html fixtures IDENTICAL. Zero rendering movement outside the previously-broken shape — every existing surface had engineered around it.

Gates: engine 323 + html suites green, clippy --all-targets both crates, 30/30 node==web determinism warning-free, chains hold.