### PR TITLE
Runs path applies the same per-char font fallback rule as single-style text

### DIFF
--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -5023,23 +5023,38 @@ impl LayoutEngine {
             return vec![];
         }
 
-        // Pre-resolve per-char font families from comma chains.
-        // This produces a vec of resolved single family names, one per char.
+        // Pre-resolve per-char font families — the same rule as
+        // segment_by_font (the single-style path) and char_width
+        // (measurement): the declared family when it covers the char,
+        // per-char resolution otherwise. This path used to skip per-char
+        // resolution entirely for comma-less families, so a non-WinAnsi
+        // char in a TextRun rendered "?" on the base-14 path while the
+        // identical char in single-style Text reached builtin Noto Sans —
+        // measurement and rendering disagreeing about the char's font.
         let resolved_families: Vec<String> = chars
             .iter()
             .map(|sc| {
+                let italic = matches!(sc.font_style, FontStyle::Italic | FontStyle::Oblique);
                 if !sc.font_family.contains(',') {
-                    sc.font_family.clone()
-                } else {
-                    let italic = matches!(sc.font_style, FontStyle::Italic | FontStyle::Oblique);
-                    let (_, family) = font_context.registry().resolve_for_char(
-                        &sc.font_family,
-                        sc.ch,
-                        sc.font_weight,
-                        italic,
-                    );
-                    family
+                    let primary =
+                        font_context
+                            .registry()
+                            .resolve(&sc.font_family, sc.font_weight, italic);
+                    if sc.ch.is_whitespace()
+                        || sc.ch == PAGE_NUMBER_SENTINEL
+                        || sc.ch == TOTAL_PAGES_SENTINEL
+                        || primary.has_char(sc.ch)
+                    {
+                        return sc.font_family.clone();
+                    }
                 }
+                let (_, family) = font_context.registry().resolve_for_char(
+                    &sc.font_family,
+                    sc.ch,
+                    sc.font_weight,
+                    italic,
+                );
+                family
             })
             .collect();
 

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -12444,3 +12444,32 @@ fn border_or_background_on_text_node_reports_render_defect() {
         "background defect must be reported: {warnings:?}"
     );
 }
+
+#[test]
+fn multi_style_runs_fall_back_to_builtin_noto_like_single_style_text() {
+    // A non-WinAnsi char in a multi-style RUN rendered as "?" while the
+    // identical char in single-style Text reached builtin Noto Sans: the
+    // runs path pre-resolved per-char fonts only for comma chains, so
+    // measurement (char_width, which falls back per-char) and rendering
+    // disagreed about which font the char takes. Both paths must apply
+    // the same rule: primary family when it covers the char, per-char
+    // resolution when it does not. Cyrillic is the probe because the
+    // bundled Noto Sans covers it ("≤" — the case that surfaced this —
+    // is NOT in the bundled font at all; that coverage gap is a separate
+    // finding the fallback machinery cannot fix).
+    let json = r#"{
+        "children": [
+            { "kind": { "type": "Text", "content": "", "runs": [
+                  { "content": "x " },
+                  { "content": "Жук", "font_weight": 700 }
+              ] }, "style": {}, "children": [] }
+        ],
+        "metadata": {}
+    }"#;
+    let bytes = forme::render_json(json).expect("runs with non-WinAnsi char render");
+    let pdf_str = String::from_utf8_lossy(&bytes);
+    assert!(
+        pdf_str.contains("NotoSans"),
+        "the runs path must embed builtin Noto Sans for a non-WinAnsi char"
+    );
+}


### PR DESCRIPTION
**Diagnosis (deeper than the parked finding):** two distinct defects were hiding under "base-14 preview path skips the Noto fallback".

1. **The routing divergence (fixed here):** `build_positioned_glyphs_runs` pre-resolved per-char fonts only for comma-chain families — a single family skipped coverage checking entirely, so a non-WinAnsi char in a multi-style TextRun rendered "?" while the identical char in single-style Text reached builtin Noto via `segment_by_font`. Measurement (`char_width`, which falls back per-char) and rendering disagreed about the char's font. The pre-resolution now applies the same rule as `segment_by_font` and `char_width`: declared family when it covers the char, per-char resolution when it doesn't. Both paths take the same route.

2. **The "≤" case itself is NOT fixable by routing** — reported, not waved through: the bundled `NotoSans-Regular.ttf` (v2.015, 2,965 codepoints) maps only ONE character in the U+2200–22FF math block. "≤", "≥", "≠" are absent from the fallback font entirely, on every path. Closing it needs a font decision — a newer upstream Noto Sans build (current upstream covers the text-font math subset) or an appended math-operators subset font — with WASM-size consequences (measured sizes are marketing-tracked in stats.ts). Left open for that call.

**Pin (failed before the fix, verified by stash/unstash):** Cyrillic in a bold TextRun must embed builtin Noto Sans.

**Blast radius:** byte-wall 6/6 IDENTICAL, corpus 15/15 IDENTICAL, Northmoor 30/30 IDENTICAL — no existing surface carries non-WinAnsi runs on the base-14 path.

Gates: engine + html suites green, clippy --all-targets both crates.