### PR TITLE
Expose the content audit through @formepdf/core

### DIFF
--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -208,7 +208,11 @@ pub fn render_with_warnings(document: &Document) -> Result<(Vec<u8>, Vec<String>
 
 /// Opt-in per-render checks. `Default` disables everything, and every
 /// disabled check costs nothing — the flag is tested once per render.
-#[derive(Debug, Clone, Copy, Default)]
+/// Deserializes from the camelCase JSON the JS wrappers send
+/// (`{"auditContent": true}`), unknown fields ignored so older engines
+/// tolerate newer wrappers.
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
 pub struct RenderOptions {
     /// Post-render content audit: after layout, verify the laid-out pages
     /// against the input document and report content that was dropped,
@@ -400,6 +404,18 @@ pub fn render_json_with_layout(
 ) -> Result<(Vec<u8>, LayoutInfo, Vec<String>), FormeError> {
     let document: Document = serde_json::from_str(json)?;
     render_with_layout(&document)
+}
+
+/// Like [`render_json_with_layout`], with opt-in [`RenderOptions`] — the
+/// JSON-input mirror of [`render_with_layout_and_options`], used by the
+/// WASM bindings so `@formepdf/core` callers can opt into the content
+/// audit the way the HTML path already can.
+pub fn render_json_with_layout_and_options(
+    json: &str,
+    options: RenderOptions,
+) -> Result<(Vec<u8>, LayoutInfo, Vec<String>, u32), FormeError> {
+    let document: Document = serde_json::from_str(json)?;
+    render_with_layout_and_options(&document, options)
 }
 
 /// Render a template with data to PDF bytes.

--- a/engine/src/wasm.rs
+++ b/engine/src/wasm.rs
@@ -67,9 +67,21 @@ pub fn redact_text(pdf_bytes: &[u8], patterns_json: &str) -> Result<Vec<u8>, JsV
 }
 
 #[wasm_bindgen]
-pub fn render_pdf_with_layout(json: &str) -> Result<JsValue, JsValue> {
-    let (pdf_bytes, layout_info, warnings) =
-        crate::render_json_with_layout(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+pub fn render_pdf_with_layout(
+    json: &str,
+    options_json: Option<String>,
+) -> Result<JsValue, JsValue> {
+    // Optional trailing parameter — existing single-argument callers get
+    // `RenderOptions::default()`, the exact code path this function always
+    // took (a disabled check costs nothing; byte-identity is gated).
+    let options: crate::RenderOptions = match options_json.as_deref() {
+        Some(s) => serde_json::from_str(s)
+            .map_err(|e| JsValue::from_str(&format!("Invalid render options: {}", e)))?,
+        None => crate::RenderOptions::default(),
+    };
+    let (pdf_bytes, layout_info, warnings, _passes) =
+        crate::render_json_with_layout_and_options(json, options)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = js_sys::Object::new();
     let pdf_array = js_sys::Uint8Array::from(pdf_bytes.as_slice());

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,3 +1,4 @@
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
 /**
  * Browser / edge entry point for @formepdf/core.
  *
@@ -69,9 +70,10 @@ export async function renderPdf(json: string): Promise<Uint8Array> {
   return wasmRenderPdf(json);
 }
 
-export async function renderPdfWithLayout(json: string): Promise<RenderWithLayoutResult> {
-  const result = wasmRenderPdfWithLayout(json) as { pdf: Uint8Array; layout: LayoutInfo; warnings?: string[] };
-  return { ...result, warnings: result.warnings ?? [] };
+export async function renderPdfWithLayout(json: string, options?: RenderDocumentOptions): Promise<RenderWithLayoutResult> {
+  return toRenderWithLayoutResult(
+    wasmRenderPdfWithLayout(json, encodeRenderOptions(options)) as RawLayoutResult,
+  );
 }
 
 export async function renderDocument(
@@ -105,7 +107,7 @@ export async function renderDocumentWithLayout(
   }
   applyAttachmentOptions(doc, options);
   await Promise.all([resolveFonts(doc), resolveImages(doc)]);
-  return renderPdfWithLayout(JSON.stringify(doc));
+  return renderPdfWithLayout(JSON.stringify(doc), options);
 }
 
 // ── Serialized document rendering ────────────────────────────────────
@@ -148,7 +150,7 @@ export async function renderSerializedDocWithLayout(
   }
   applyAttachmentOptions(doc, options);
   await Promise.all([resolveFonts(doc), resolveImages(doc)]);
-  return renderPdfWithLayout(JSON.stringify(doc));
+  return renderPdfWithLayout(JSON.stringify(doc), options);
 }
 
 // ── Template rendering ──────────────────────────────────────────────

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,4 +1,4 @@
-import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result.js';
 /**
  * Browser / edge entry point for @formepdf/core.
  *

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@ import { render_pdf as wasmRenderPdf } from '../pkg-node/forme.js';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { ReactElement } from 'react';
-import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result.js';
 import { applyAttachmentOptions, type AttachmentOptions, type FacturXOptions } from './attachments.js';
 
 // ── Layout metadata types ──────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ import { render_pdf as wasmRenderPdf } from '../pkg-node/forme.js';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { ReactElement } from 'react';
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
 import { applyAttachmentOptions, type AttachmentOptions, type FacturXOptions } from './attachments.js';
 
 // ── Layout metadata types ──────────────────────────────────────────
@@ -363,10 +364,11 @@ export async function renderPdf(json: string): Promise<Uint8Array> {
   return wasmRenderPdf(json);
 }
 
-export async function renderPdfWithLayout(json: string): Promise<RenderWithLayoutResult> {
+export async function renderPdfWithLayout(json: string, options?: RenderDocumentOptions): Promise<RenderWithLayoutResult> {
   const { render_pdf_with_layout } = await import('../pkg-node/forme.js');
-  const result = render_pdf_with_layout(json) as { pdf: Uint8Array; layout: LayoutInfo; warnings?: string[] };
-  return { ...result, warnings: result.warnings ?? [] };
+  return toRenderWithLayoutResult(
+    render_pdf_with_layout(json, encodeRenderOptions(options)) as RawLayoutResult,
+  );
 }
 
 export interface CertificationConfig {
@@ -404,6 +406,20 @@ export interface RenderDocumentOptions {
    * `<Document>`. Forme does not generate or validate the XML itself.
    */
   facturX?: FacturXOptions;
+  /**
+   * Opt-in post-render content audit (mirrors the HTML path's
+   * `auditContent`): after layout, the engine verifies the laid-out
+   * pages against the input document and reports content that was
+   * dropped, rendered fully off-page, painted in exactly its
+   * background's colour, or clipped to a zero-size box — as
+   * `render defect:` entries in the result's `warnings`. Findings need
+   * a warnings channel, so the flag is honored by
+   * `renderDocumentWithLayout` / `renderSerializedDocWithLayout`
+   * (`renderDocument` returns bare bytes and has nowhere to report).
+   * Off by default; when off the render takes the exact historical
+   * code path and output is byte-identical.
+   */
+  auditContent?: boolean;
 }
 
 export async function renderDocument(element: ReactElement, options?: RenderDocumentOptions): Promise<Uint8Array> {
@@ -461,7 +477,7 @@ export async function renderSerializedDocWithLayout(
   }
   applyAttachmentOptions(doc, options);
   await Promise.all([resolveFonts(doc), resolveImages(doc)]);
-  return renderPdfWithLayout(JSON.stringify(doc));
+  return renderPdfWithLayout(JSON.stringify(doc), options);
 }
 
 // ── Template rendering ──────────────────────────────────────────────
@@ -473,8 +489,9 @@ export async function renderTemplate(templateJson: string, dataJson: string): Pr
 
 export async function renderTemplateWithLayout(templateJson: string, dataJson: string): Promise<RenderWithLayoutResult> {
   const { render_template_pdf_with_layout } = await import('../pkg-node/forme.js');
-  const result = render_template_pdf_with_layout(templateJson, dataJson) as { pdf: Uint8Array; layout: LayoutInfo; warnings?: string[] };
-  return { ...result, warnings: result.warnings ?? [] };
+  return toRenderWithLayoutResult(
+    render_template_pdf_with_layout(templateJson, dataJson) as RawLayoutResult,
+  );
 }
 
 // ── PDF certification ────────────────────────────────────────────────

--- a/packages/core/src/shared/result.ts
+++ b/packages/core/src/shared/result.ts
@@ -7,7 +7,7 @@
 // where a field added to the declared type reached one construction out
 // of six. Agreement by construction: every entry funnels through this
 // function, so a new field is added exactly here.
-import type { LayoutInfo } from '../index';
+import type { LayoutInfo } from '../index.js';
 
 export interface RawLayoutResult {
   pdf: Uint8Array;

--- a/packages/core/src/shared/result.ts
+++ b/packages/core/src/shared/result.ts
@@ -1,0 +1,38 @@
+// @formepdf/core — the ONE place a raw WASM layout result becomes the
+// public RenderWithLayoutResult.
+//
+// The node, browser, and worker entries (plus the template path) each
+// built this object by hand with the same `warnings ?? []` fixup — the
+// exact shape that produced the html package's `passes` divergence,
+// where a field added to the declared type reached one construction out
+// of six. Agreement by construction: every entry funnels through this
+// function, so a new field is added exactly here.
+import type { LayoutInfo } from '../index';
+
+export interface RawLayoutResult {
+  pdf: Uint8Array;
+  layout: LayoutInfo;
+  warnings?: string[];
+}
+
+export interface RenderWithLayoutResultShape {
+  pdf: Uint8Array;
+  layout: LayoutInfo;
+  warnings: string[];
+}
+
+export function toRenderWithLayoutResult(raw: RawLayoutResult): RenderWithLayoutResultShape {
+  return { pdf: raw.pdf, layout: raw.layout, warnings: raw.warnings ?? [] };
+}
+
+/**
+ * Serialize the per-render engine options (`RenderOptions` on the Rust
+ * side) for the WASM boundary. Returns `undefined` when every option is
+ * off, so the default render takes the exact historical code path —
+ * "costs nothing when off" is enforced by construction, not by hoping
+ * the engine ignores an empty object cheaply.
+ */
+export function encodeRenderOptions(options?: { auditContent?: boolean }): string | undefined {
+  if (!options?.auditContent) return undefined;
+  return JSON.stringify({ auditContent: true });
+}

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,3 +1,4 @@
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
 /**
  * Cloudflare Workers / edge entry point for @formepdf/core.
  *
@@ -108,11 +109,12 @@ export async function renderPdf(json: string): Promise<Uint8Array> {
   return wasmRenderPdf(json);
 }
 
-export async function renderPdfWithLayout(json: string): Promise<RenderWithLayoutResult> {
+export async function renderPdfWithLayout(json: string, options?: RenderDocumentOptions): Promise<RenderWithLayoutResult> {
   ensureInit();
   await initPromise;
-  const result = wasmRenderPdfWithLayout(json) as { pdf: Uint8Array; layout: LayoutInfo; warnings?: string[] };
-  return { ...result, warnings: result.warnings ?? [] };
+  return toRenderWithLayoutResult(
+    wasmRenderPdfWithLayout(json, encodeRenderOptions(options)) as RawLayoutResult,
+  );
 }
 
 export async function renderDocument(
@@ -146,7 +148,7 @@ export async function renderDocumentWithLayout(
   }
   applyAttachmentOptions(doc, options);
   await Promise.all([resolveFonts(doc), resolveImages(doc)]);
-  return renderPdfWithLayout(JSON.stringify(doc));
+  return renderPdfWithLayout(JSON.stringify(doc), options);
 }
 
 // ── Serialized document rendering ────────────────────────────────────
@@ -178,7 +180,7 @@ export async function renderSerializedDocWithLayout(
   }
   applyAttachmentOptions(doc, options);
   await Promise.all([resolveFonts(doc), resolveImages(doc)]);
-  return renderPdfWithLayout(JSON.stringify(doc));
+  return renderPdfWithLayout(JSON.stringify(doc), options);
 }
 
 // ── Template rendering ──────────────────────────────────────────────

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,4 +1,4 @@
-import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result';
+import { toRenderWithLayoutResult, encodeRenderOptions, type RawLayoutResult } from './shared/result.js';
 /**
  * Cloudflare Workers / edge entry point for @formepdf/core.
  *

--- a/packages/core/tests/audit-content.test.ts
+++ b/packages/core/tests/audit-content.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { serialize, Document, Page, View, Text } from '@formepdf/react';
+import { renderSerializedDocWithLayout } from '../src/index';
+
+const h = React.createElement;
+
+/** White text on a white background — the audit's "painted in exactly the
+ *  colour of the ground under it" case, invisible by construction. */
+function invisibleTextDoc() {
+  return serialize(
+    h(
+      Document,
+      null,
+      h(
+        Page,
+        { size: 'Letter', margin: 48 },
+        h(
+          View,
+          { style: { backgroundColor: '#ffffff', padding: 8 } },
+          h(Text, { style: { color: '#ffffff' } }, 'invisible confirmation code'),
+        ),
+      ),
+    ),
+  ) as Record<string, unknown>;
+}
+
+describe('auditContent through @formepdf/core (mirrors the HTML path)', () => {
+  it('reports invisible content as render defects in warnings when enabled', async () => {
+    const { warnings } = await renderSerializedDocWithLayout(invisibleTextDoc(), {
+      auditContent: true,
+    });
+    expect(
+      warnings.some((w) => w.startsWith('render defect:')),
+      `expected an audit defect, got: ${JSON.stringify(warnings)}`,
+    ).toBe(true);
+  });
+
+  it('costs nothing when off: byte-identical output, no audit warnings', async () => {
+    const plain = await renderSerializedDocWithLayout(invisibleTextDoc());
+    const explicitOff = await renderSerializedDocWithLayout(invisibleTextDoc(), {
+      auditContent: false,
+    });
+    expect(Buffer.from(explicitOff.pdf).equals(Buffer.from(plain.pdf))).toBe(true);
+    expect(plain.warnings.some((w) => w.startsWith('render defect:'))).toBe(false);
+    expect(explicitOff.warnings.some((w) => w.startsWith('render defect:'))).toBe(false);
+  });
+
+  it('the audit changes warnings only — PDF bytes stay byte-identical', async () => {
+    const off = await renderSerializedDocWithLayout(invisibleTextDoc());
+    const on = await renderSerializedDocWithLayout(invisibleTextDoc(), { auditContent: true });
+    expect(Buffer.from(on.pdf).equals(Buffer.from(off.pdf))).toBe(true);
+  });
+});


### PR DESCRIPTION
The post-render content audit was reachable from the HTML path only. `auditContent` now mirrors through `RenderDocumentOptions`: findings arrive as `render defect:` entries in `warnings`, honored by the WithLayout variants (`renderDocument` returns bare bytes and has no warnings channel — documented on the option).

**Shared result construction, per the passes-bug lesson:** node, browser, worker, and the template path each hand-built the result object with the same `warnings ?? []` fixup — four constructions. All four now funnel through `packages/core/src/shared/result.ts`; a future field is added in exactly one place. `encodeRenderOptions` returns `undefined` when everything is off, so the default render takes the exact historical WASM call — zero cost when off by construction, not by hope.

Engine: `render_pdf_with_layout` gains an optional trailing options JSON (single-argument callers unchanged); `RenderOptions` deserializes camelCase, unknown fields ignored; `render_json_with_layout_and_options` added as the JSON-input mirror.

**Pins** (the audit case verified failing against the previous WASM before the rebuild; byte-identity held throughout):
- white-on-white text + `auditContent: true` → a `render defect:` warning
- off (default and explicit `false`) → byte-identical output, no audit warnings
- on → warnings change only; PDF bytes stay byte-identical

Gates: core 89 tests green, engine suites + clippy --all-targets clean, byte-wall 6/6 IDENTICAL, 30/30 Northmoor node==web determinism warning-free.