### PR TITLE
Missing-glyph substitution warns; Northmoor spec limits in the max idiom

### DIFF
--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -142,6 +142,14 @@ struct PdfBuilder {
     /// embeddable font). Returned to the caller so every render surface can
     /// show them, never silently dropped.
     warnings: Vec<String>,
+    /// Characters replaced by "?" because no available font covers them —
+    /// not WinAnsi, not the bundled Noto, not a registered font. RefCell
+    /// because the substitution sites run under `&self` (write_element is
+    /// recursive; chart labels render through a free fn holding `&PdfBuilder`).
+    /// Drained into one warning per distinct character at the end of the
+    /// write: a silently wrong glyph is a render defect (decision 2026-09-08 —
+    /// keep the bundled font, make the register-a-font path discoverable).
+    missing_glyphs: std::cell::RefCell<std::collections::BTreeSet<char>>,
 }
 
 pub(crate) struct PdfObject {
@@ -272,6 +280,7 @@ impl PdfWriter {
             ext_gstate_map: HashMap::new(),
             shading_map: HashMap::new(),
             warnings: Vec::new(),
+            missing_glyphs: Default::default(),
         };
 
         // Reserve object IDs:
@@ -1320,7 +1329,18 @@ impl PdfWriter {
         };
 
         let pdf = self.serialize(&builder, info_obj_id);
-        Ok((pdf, builder.warnings))
+        // One warning per distinct substituted character (BTreeSet order is
+        // deterministic). Page sentinels never reach the encoders, and a
+        // literal "?" maps through WinAnsi — only genuinely uncovered
+        // characters land here.
+        let mut warnings = builder.warnings;
+        for ch in builder.missing_glyphs.into_inner() {
+            warnings.push(format!(
+                "render defect: \"{ch}\" (U+{:04X}) is not covered by any available font and was rendered as \"?\" — register a font containing it (Font.register, the Document fonts prop, or @font-face on the HTML path)",
+                ch as u32
+            ));
+        }
+        Ok((pdf, warnings))
     }
 
     /// Build the PDF content stream for a single page.
@@ -1793,7 +1813,10 @@ impl PdfWriter {
                                 .replace(&tp, &total_pages.to_string());
                             let mut text_str = String::new();
                             for ch in text_after.chars() {
-                                let b = Self::unicode_to_winansi(ch).unwrap_or(b'?');
+                                let b = Self::unicode_to_winansi(ch).unwrap_or_else(|| {
+                                    builder.missing_glyphs.borrow_mut().insert(ch);
+                                    b'?'
+                                });
                                 match b {
                                     b'\\' => text_str.push_str("\\\\"),
                                     b'(' => text_str.push_str("\\("),
@@ -2355,7 +2378,7 @@ impl PdfWriter {
                                         if ly < pdf_y {
                                             break;
                                         }
-                                        let esc = Self::encode_winansi_text(line_text);
+                                        let esc = Self::encode_winansi_text(builder, line_text);
                                         let _ = writeln!(
                                             stream,
                                             "BT /F{} {:.1} Tf 0 g {:.2} {:.2} Td ({}) Tj ET",
@@ -2367,7 +2390,7 @@ impl PdfWriter {
                                         );
                                     }
                                 } else {
-                                    let escaped = Self::encode_winansi_text(&display_text);
+                                    let escaped = Self::encode_winansi_text(builder, &display_text);
                                     let text_y = pdf_y + (h - font_size) / 2.0;
                                     let _ = writeln!(
                                         stream,
@@ -2393,7 +2416,7 @@ impl PdfWriter {
                                         })
                                         .map(|(i, _)| i)
                                         .unwrap_or(0);
-                                    let escaped = Self::encode_winansi_text(ph);
+                                    let escaped = Self::encode_winansi_text(builder, ph);
                                     let text_y = pdf_y + (h - font_size) / 2.0;
                                     let _ = writeln!(
                                         stream,
@@ -2432,7 +2455,7 @@ impl PdfWriter {
                                         })
                                         .map(|(i, _)| i)
                                         .unwrap_or(0);
-                                    let escaped = Self::encode_winansi_text(val);
+                                    let escaped = Self::encode_winansi_text(builder, val);
                                     let text_y = pdf_y + (h - font_size) / 2.0;
                                     let _ = writeln!(
                                         stream,
@@ -4185,11 +4208,15 @@ impl PdfWriter {
     }
 
     /// Encode a string for use in a PDF content stream with WinAnsi encoding.
-    /// Characters outside WinAnsi range are replaced with '?'.
-    fn encode_winansi_text(s: &str) -> String {
+    /// Characters outside WinAnsi range are replaced with '?' and recorded
+    /// for the missing-glyph render defect.
+    fn encode_winansi_text(builder: &PdfBuilder, s: &str) -> String {
         let mut result = String::with_capacity(s.len());
         for ch in s.chars() {
-            let b = Self::unicode_to_winansi(ch).unwrap_or(b'?');
+            let b = Self::unicode_to_winansi(ch).unwrap_or_else(|| {
+                builder.missing_glyphs.borrow_mut().insert(ch);
+                b'?'
+            });
             match b {
                 b'\\' => result.push_str("\\\\"),
                 b'(' => result.push_str("\\("),
@@ -4466,6 +4493,7 @@ fn write_chart_primitive(
                     } else if (ch as u32) >= 32 && (ch as u32) <= 255 {
                         ch
                     } else {
+                        builder.missing_glyphs.borrow_mut().insert(ch);
                         '?'
                     }
                 })

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -12579,3 +12579,55 @@ fn multi_style_runs_fall_back_to_builtin_noto_like_single_style_text() {
         "the runs path must embed builtin Noto Sans for a non-WinAnsi char"
     );
 }
+
+#[test]
+fn unmapped_glyph_reports_a_render_defect_naming_the_character() {
+    // "≤" has no WinAnsi byte and is not in the bundled Noto Sans either
+    // (v2.015 maps one char of the U+2200–22FF math block) — so it
+    // renders as "?" on every path. That substitution was SILENT: the
+    // reader sees a wrong character and nothing says so. The decision
+    // (2026-09-08) is to keep the bundled font as-is — the documented
+    // path for out-of-coverage glyphs is registering a font — and make
+    // that path discoverable: the substitution reports through the
+    // render-defect channel, naming the character.
+    let json = r#"{
+        "children": [
+            { "kind": { "type": "Text", "content": "x ≤ 5" }, "style": {}, "children": [] }
+        ],
+        "metadata": {}
+    }"#;
+    let (_pdf, warnings) = {
+        let doc: forme::Document = serde_json::from_str(json).expect("parse");
+        forme::render_with_warnings(&doc).expect("render")
+    };
+    let defect = warnings
+        .iter()
+        .find(|w| w.starts_with("render defect:") && w.contains("U+2264"));
+    assert!(
+        defect.is_some(),
+        "the '?' substitution must report itself: {warnings:?}"
+    );
+    assert!(
+        defect.unwrap().contains("register a font"),
+        "the message must point at the fix: {}",
+        defect.unwrap()
+    );
+}
+
+#[test]
+fn covered_text_reports_no_missing_glyph_defect() {
+    // ASCII (WinAnsi) and Cyrillic (bundled Noto) both have real glyph
+    // sources — no substitution, no warning.
+    let json = r#"{
+        "children": [
+            { "kind": { "type": "Text", "content": "plain Жук text" }, "style": {}, "children": [] }
+        ],
+        "metadata": {}
+    }"#;
+    let doc: forme::Document = serde_json::from_str(json).expect("parse");
+    let (_pdf, warnings) = forme::render_with_warnings(&doc).expect("render");
+    assert!(
+        !warnings.iter().any(|w| w.contains("rendered as \"?\"")),
+        "covered text must not warn: {warnings:?}"
+    );
+}

--- a/templates/inspection-report/index.html
+++ b/templates/inspection-report/index.html
@@ -52,7 +52,7 @@
     <tr class="ghead"><td colspan="7">Section 2 — Dimensional</td></tr>
     <tr><td>2.1</td><td>Overall length</td><td>96.00 in ± 0.06</td><td>95.98 – 96.03</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>
     <tr><td>2.2</td><td>Overall width</td><td>48.00 in ± 0.06</td><td>47.99 – 48.02</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>
-    <tr><td>2.3</td><td>Diagonal difference, squareness</td><td>≤ 0.12 in</td><td>0.07 max</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>
+    <tr><td>2.3</td><td>Diagonal difference, squareness</td><td>0.12 in max</td><td>0.07 max</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>
     <tr><td>2.4</td><td>Mounting hole pattern, position</td><td>± 0.03 in to datum B</td><td>0.02 max</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>
     <tr class="ghead"><td colspan="7">Section 3 — Welding and finish</td></tr>
     <tr><td>3.1</td><td>Visual weld inspection, all joints</td><td>AWS D1.1 table 6.1</td><td>Accept</td><td><div class="ck"></div></td><td><div class="ck"></div></td><td><div class="ck"></div></td></tr>

--- a/templates/lab-report/index.html
+++ b/templates/lab-report/index.html
@@ -48,13 +48,13 @@
   <thead><tr><th scope="col" style="width: 25.5pt">No.</th><th scope="col">Analyte</th><th scope="col" style="width: 55.5pt">Method</th><th scope="col" class="num" style="width: 58.5pt">Result</th><th scope="col" style="width: 42pt">Unit</th><th scope="col" class="num" style="width: 78pt">Reference range</th><th scope="col" style="width: 49.5pt">Assessment</th></tr></thead>
   <tbody>
     <tr><td>1</td><td>pH at 25 °C</td><td>SM 4500-H+</td><td class="num">6.8</td><td>pH</td><td class="num">6.5 – 8.5</td><td>Within</td></tr>
-    <tr><td>2</td><td>Conductivity</td><td>SM 2510 B</td><td class="num">0.9</td><td>µS/cm</td><td class="num">≤ 1.3</td><td>Within</td></tr>
-    <tr><td>3</td><td>Total organic carbon</td><td>SM 5310 C</td><td class="num">0.31</td><td>mg/L</td><td class="num">≤ 0.50</td><td>Within</td></tr>
-    <tr><td>4</td><td>Total hardness as CaCO₃</td><td>SM 2340 C</td><td class="num">&lt; 1.0</td><td>mg/L</td><td class="num">≤ 1.0</td><td>Within</td></tr>
-    <tr><td>5</td><td>Chloride</td><td>EPA 300.0</td><td class="num">0.42</td><td>mg/L</td><td class="num">≤ 1.00</td><td>Within</td></tr>
-    <tr><td>6</td><td>Iron, total</td><td>EPA 200.7</td><td class="num">0.014</td><td>mg/L</td><td class="num">≤ 0.050</td><td>Within</td></tr>
-    <tr><td>7</td><td>Heterotrophic plate count, 48 h</td><td>SM 9215 B</td><td class="num flag flagval">138</td><td>CFU/mL</td><td class="num">≤ 100</td><td class="flag">Exceeds</td></tr>
-    <tr><td>8</td><td>Bacterial endotoxin</td><td>USP &lt;85&gt; LAL</td><td class="num">0.06</td><td>EU/mL</td><td class="num">≤ 0.25</td><td>Within</td></tr>
+    <tr><td>2</td><td>Conductivity</td><td>SM 2510 B</td><td class="num">0.9</td><td>µS/cm</td><td class="num">1.3 max</td><td>Within</td></tr>
+    <tr><td>3</td><td>Total organic carbon</td><td>SM 5310 C</td><td class="num">0.31</td><td>mg/L</td><td class="num">0.50 max</td><td>Within</td></tr>
+    <tr><td>4</td><td>Total hardness as CaCO₃</td><td>SM 2340 C</td><td class="num">&lt; 1.0</td><td>mg/L</td><td class="num">1.0 max</td><td>Within</td></tr>
+    <tr><td>5</td><td>Chloride</td><td>EPA 300.0</td><td class="num">0.42</td><td>mg/L</td><td class="num">1.00 max</td><td>Within</td></tr>
+    <tr><td>6</td><td>Iron, total</td><td>EPA 200.7</td><td class="num">0.014</td><td>mg/L</td><td class="num">0.050 max</td><td>Within</td></tr>
+    <tr><td>7</td><td>Heterotrophic plate count, 48 h</td><td>SM 9215 B</td><td class="num flag flagval">138</td><td>CFU/mL</td><td class="num">100 max</td><td class="flag">Exceeds</td></tr>
+    <tr><td>8</td><td>Bacterial endotoxin</td><td>USP &lt;85&gt; LAL</td><td class="num">0.06</td><td>EU/mL</td><td class="num">0.25 max</td><td>Within</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Two commits, separately revertable:

**1. The warning.** A character with no glyph source anywhere — not WinAnsi, not the bundled Noto, not a registered font — rendered as "?" silently at three sites (body text, AcroForm fields, chart labels). All three now record the character, drained into one warning per distinct char: `render defect: "≤" (U+2264) is not covered by any available font and was rendered as "?" — register a font containing it (Font.register, the Document fonts prop, or @font-face on the HTML path)`. Division of labor per the 2026-09-08 decision: bundled coverage stays small; the warning names the gap and the remedy. Pins fails-first both ways; byte-wall 6/6 IDENTICAL (warnings only).

**2. What its first run caught.** lab-report (7×) and inspection-report (1×) had been printing "?" for "≤" since the port — past the content audit (text content was right, only the glyph missing). Reworded to the idiom the documents already use ("0.07 max" sits in inspection-report's neighboring column): "≤ 1.3" → "1.3 max", "≤ 0.12 in" → "0.12 in max".

**Coverage sweep** (as requested): static scan of all thirty templates' text against WinAnsi + bundled-Noto cmaps, both weights — "≤" was the only uncovered character; subscripts (₃) and µ are covered. The 30-template zero-warnings determinism gate now proves this at render level every CI run.

Also observed: corpus template 08's stored warning count is one higher than the current engine produces — the removed path-based sequential-split check had been false-positive firing on 08 as well.

Gates: engine + html suites green, clippy --all-targets both crates, byte-wall 6/6 IDENTICAL, 30/30 determinism warning-free, chains + sig-hygiene green.