### PR TITLE
CI: attach every validator's report to the Forme Review upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,18 +588,6 @@ jobs:
           PARITY_DIR: ${{ github.workspace }}/parity-partials
           OUT_DIR: ${{ github.workspace }}/dist/review
         run: node scripts/verify-pdfua.mjs
-      - name: Upload the corpus to Forme Review
-        # The same 39 documents the conformance gate just rendered — five shipped
-        # templates, four HTML fixtures, thirty Northmoor documents on one shared
-        # stylesheet — uploaded as one batch. The first upload establishes each
-        # document's baseline; every PR after that is compared and reported as a
-        # check and a comment. Structure only by default; the PDFs stay here.
-        # One batch per commit: the service judges document presence when a
-        # batch completes, so nothing else in this workflow uploads.
-        env:
-          PDF_TESTKIT_SERVICE_URL: https://review-api.formepdf.com
-          PDF_TESTKIT_TOKEN: ${{ secrets.PDF_TESTKIT_TOKEN }}
-        run: npx --no-install pdf-testkit upload dist/review/*.pdf --require-service
       - name: Validate the PDF/A + PDF/UA-1 corpus
         # The same corpus rendered as BOTH PDF/A and PDF/UA-1, validated against
         # veraPDF's PDF/A-2b and PDF/A-2a profiles AND its PDF/UA-1 profile — the
@@ -623,7 +611,22 @@ jobs:
         env:
           REQUIRE_VALIDATORS: '1'
           PARITY_DIR: ${{ github.workspace }}/parity-partials
+          OUT_DIR: ${{ github.workspace }}/dist/review
         run: node scripts/verify-einvoice.mjs
+      - name: Upload the corpus to Forme Review
+        # The 39 documents the conformance gate rendered plus the Factur-X invoice,
+        # with every validator's report attached: veraPDF's for PDF/UA-1 (and
+        # PDF/A-3b on the invoice), Mustang's for EN 16931 through the documented
+        # JSON. Forme Review records the verdicts attributed to each validator; it
+        # never validates. One batch per commit. The first upload establishes each
+        # document's baseline; every PR after that is compared and reported as a
+        # check and a comment. Structure only by default; the PDFs stay here.
+        # One batch per commit: the service judges document presence when a
+        # batch completes, so nothing else in this workflow uploads.
+        env:
+          PDF_TESTKIT_SERVICE_URL: https://review-api.formepdf.com
+          PDF_TESTKIT_TOKEN: ${{ secrets.PDF_TESTKIT_TOKEN }}
+        run: npx --no-install pdf-testkit upload dist/review/*.pdf --conformance dist/review/reports/*.xml dist/review/reports/*.json --require-service
       - name: Upload parity evidence (conformance)
         uses: actions/upload-artifact@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "forme-nm",
+  "name": "forme-conf",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@pdf-testkit/cli": "^0.2.3",
+        "@pdf-testkit/cli": "^0.3.0",
         "miniflare": "4.20260730.0",
         "puppeteer-core": "25.10.0"
       }
@@ -2150,15 +2150,15 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/cli": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.2.3.tgz",
-      "integrity": "sha512-t0jdpjfbPpW2SrNVp7fNJ4m3rDAzWymq+op/Di5TN+JERrdAIMdHfq4R3ZYgY7Tk2UvaKAqaFIf7Lq4GRb/Rcg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.3.0.tgz",
+      "integrity": "sha512-PASZN2T9JXWbAT9XPtgacrrxY1B8Ac9lkwmFlBc3pebvlVIkGQWb6qIrnpx3bRk6aTraGZRUA4rEKgXkonPBZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.2.3",
-        "@pdf-testkit/matcher-core": "^0.2.3",
-        "@pdf-testkit/protocol": "^0.2.3",
+        "@pdf-testkit/core": "^0.3.0",
+        "@pdf-testkit/matcher-core": "^0.3.0",
+        "@pdf-testkit/protocol": "^0.3.0",
         "commander": "^12.1.0",
         "pdfjs-dist": "^4.10.38"
       },
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/core": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.2.3.tgz",
-      "integrity": "sha512-6RMFKqSHVCSspfjrWXPPbBmeNjEz9WlWaDJjTVYcdMyrU0aaUeHl2vbgZQL1xmJmQ6lCwKU1nB3xHI5UVvx2TQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-FHrF99ZELG1TWJv8OoQ2VIQOQUsXHoHg6DxIINTmqshcLzM5psK42/zIBcCmrjaDvo7v47+3Lv8OOwqhZr4qsA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2186,13 +2186,13 @@
       }
     },
     "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.2.3.tgz",
-      "integrity": "sha512-s2V8Hgri90YoyPBAl7Ens0bzYeHtk2jlYw6MEti0IDOteaVS5rXBUWDxtlFbn0gKdktiuYwBPIV4PPI8os9MyA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.3.0.tgz",
+      "integrity": "sha512-py5wuPgyXVWBBgFSQuU7VJS3ePsOWuU/DHOs5NQb2rg/itKjKLQWGZJGvmhtXuNjrwRHxGjDtactiCXvm8DMSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.2.3"
+        "@pdf-testkit/core": "^0.3.0"
       }
     },
     "node_modules/@pdf-testkit/core": {
@@ -2221,9 +2221,9 @@
       }
     },
     "node_modules/@pdf-testkit/protocol": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.2.3.tgz",
-      "integrity": "sha512-x5MOb1FjxO1Drb8eUmJTpHuvN7gUTkn7KzWK/d2FqRl9fEXnDi4ubO21Z//nd5vMDWR5JoWq9lBodVVru8IIZw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.3.0.tgz",
+      "integrity": "sha512-9LLLCRMhb0QunVEpMOK8UwxE9K6XmbUg129B1/NLuobjEGZ9bRODL84P9bVjVI1ms9Y5X6S2C+QbiJCf+Cr4/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2166,7 +2166,7 @@
         "pdf-testkit": "bin/pdf-testkit.js"
       }
     },
-    "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/core": {
+    "node_modules/@pdf-testkit/core": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.3.0.tgz",
       "integrity": "sha512-FHrF99ZELG1TWJv8OoQ2VIQOQUsXHoHg6DxIINTmqshcLzM5psK42/zIBcCmrjaDvo7v47+3Lv8OOwqhZr4qsA==",
@@ -2185,7 +2185,7 @@
         }
       }
     },
-    "node_modules/@pdf-testkit/cli/node_modules/@pdf-testkit/matcher-core": {
+    "node_modules/@pdf-testkit/matcher-core": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.3.0.tgz",
       "integrity": "sha512-py5wuPgyXVWBBgFSQuU7VJS3ePsOWuU/DHOs5NQb2rg/itKjKLQWGZJGvmhtXuNjrwRHxGjDtactiCXvm8DMSQ==",
@@ -2193,31 +2193,6 @@
       "license": "MIT",
       "dependencies": {
         "@pdf-testkit/core": "^0.3.0"
-      }
-    },
-    "node_modules/@pdf-testkit/core": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.1.6.tgz",
-      "integrity": "sha512-XElRuH9p8xewNGvkpVyHuGPxwW7/0nLQ8HYWqNnfNvsaJLc0g9+H29IFKeVFd+UR++iUJJqMsBiZOjE+r9MK5g==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "pdfjs-dist": "^4.10 || ^5"
-      },
-      "peerDependenciesMeta": {
-        "pdfjs-dist": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.1.6.tgz",
-      "integrity": "sha512-Uon9l7WZrBVv1t9XH02A+3xre+vP6JM6VR9IYQm3eX+g23j1WO4EbqPwl1QX6fGcAr8X43ani1SgfqYCFTBuOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pdf-testkit/core": "^0.1.6"
       }
     },
     "node_modules/@pdf-testkit/protocol": {
@@ -2231,14 +2206,14 @@
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.1.6.tgz",
-      "integrity": "sha512-IVLkE4R+RERXri6XFIv2ZB8TYey+mpiPxkS/NDH++2WxkOy1QyhnW5/CIuAxttRc05L8AfT0/oAO/1mZkzFDxQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.3.0.tgz",
+      "integrity": "sha512-HLs2PF4itpOTchC18GhUaV5PfnuiU5a2J1f7kLghSbQEF/CBpi3brFKnKAL//iC439vHGgyRO691XIr1XyQnSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.1.6",
-        "@pdf-testkit/matcher-core": "^0.1.6"
+        "@pdf-testkit/core": "^0.3.0",
+        "@pdf-testkit/matcher-core": "^0.3.0"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -7563,7 +7538,7 @@
         "@formepdf/fonts-standard": "0.20.1",
         "@formepdf/html": "^0.20.1",
         "@formepdf/templates": "0.20.1",
-        "@pdf-testkit/vitest": "^0.1.6",
+        "@pdf-testkit/vitest": "^0.3.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@pdf-testkit/cli": "^0.2.3",
+    "@pdf-testkit/cli": "^0.3.0",
     "miniflare": "4.20260730.0",
     "puppeteer-core": "25.10.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.20.1",
     "@formepdf/html": "^0.20.1",
-    "@pdf-testkit/vitest": "^0.1.6",
+    "@pdf-testkit/vitest": "^0.3.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/scripts/parity/lib.mjs
+++ b/scripts/parity/lib.mjs
@@ -57,5 +57,58 @@ export function veraValidate(vera, flavour, pdfPath) {
       description: m[4],
     });
   }
-  return { pass, failedClauses };
+  return { pass, failedClauses, xml };
+}
+
+/**
+ * Keep a validator's raw report where Forme Review's upload step can attach
+ * it (`--conformance`). No-op unless OUT_DIR is set. The report names the PDF
+ * by its path under OUT_DIR, which is also the path the upload names it by.
+ */
+export function keepReport(name, text) {
+  const dir = process.env.OUT_DIR;
+  if (!dir) return null;
+  const reports = join(dir, 'reports');
+  mkdirSync(reports, { recursive: true });
+  const p = join(reports, name);
+  writeFileSync(p, text);
+  return p;
+}
+
+/**
+ * Mustang's validation report → the documented `forme-review-conformance/1`
+ * shape. Forme Review parses veraPDF and nothing else by policy; every other
+ * validator, including this one that we run ourselves, goes through this JSON.
+ * The verdict is Mustang's summary; each typed error or exception becomes a
+ * failure with the type as its clause. Attributed to Mustang by version.
+ */
+export function mustangToConformance(reportXml, { documentPath, jarPath, file = null }) {
+  const status = (reportXml.match(/<summary status="([a-z]+)"\/>\s*<\/validation>/) ?? reportXml.match(/<summary status="([a-z]+)"\/>/))?.[1] ?? null;
+  const verdict = status === 'valid' ? 'pass' : status === 'invalid' ? 'fail' : 'error';
+  const failures = [];
+  for (const m of reportXml.matchAll(/<(error|exception|criterion)\b([^>]*)>([^<]*)<\/\1>/g)) {
+    const type = m[2].match(/type="([^"]+)"/)?.[1] ?? m[1];
+    failures.push({ clause: `${m[1]}/${type}`, test: null, count: 1, description: m[3].trim().slice(0, 300) });
+  }
+  const ranAt = reportXml.match(/datetime="([^"]+)"/)?.[1];
+  const result = {
+    profile: 'Factur-X EN 16931',
+    verdict,
+    tool: { name: 'Mustang', version: mustangVersion(jarPath) },
+    ran_at: ranAt ? new Date(ranAt.replace(' ', 'T') + 'Z').toISOString() : null,
+    source: { format: 'mustang-report-xml', file },
+    failure_count: failures.length,
+    failures: failures.slice(0, 200),
+  };
+  return { format: 'forme-review-conformance/1', documents: { [documentPath]: [result] } };
+}
+
+export function mustangVersion(jarPath) {
+  if (process.env.MUSTANG_VERSION) return process.env.MUSTANG_VERSION;
+  try {
+    const manifest = execFileSync('unzip', ['-p', jarPath, 'META-INF/MANIFEST.MF'], { encoding: 'utf8' });
+    return manifest.match(/Implementation-Version:\s*([^\s]+)/)?.[1] ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }

--- a/scripts/verify-einvoice.mjs
+++ b/scripts/verify-einvoice.mjs
@@ -18,7 +18,7 @@
 // PARITY_DIR: also emit the structured evidence section.
 
 import { execFileSync } from 'node:child_process';
-import { emitSection } from './parity/lib.mjs';
+import { emitSection, keepReport, mustangToConformance, veraValidate } from './parity/lib.mjs';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -51,16 +51,6 @@ function invoiceDoc() {
 function findTool(env, fallback) {
   const c = process.env[env] || fallback;
   return existsSync(c) ? c : null;
-}
-
-function veraCompliant(vera, pdfPath, flavour) {
-  try {
-    const out = execFileSync(vera, ['-f', flavour, pdfPath], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-    return out.includes('isCompliant="true"');
-  } catch (e) {
-    // veraPDF exits non-zero on non-compliance but still prints the report
-    return String(e.stdout || '').includes('isCompliant="true"');
-  }
 }
 
 /** veraPDF verdict, with the raw report kept for Forme Review. */

--- a/scripts/verify-einvoice.mjs
+++ b/scripts/verify-einvoice.mjs
@@ -19,7 +19,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { emitSection } from './parity/lib.mjs';
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -63,6 +63,13 @@ function veraCompliant(vera, pdfPath, flavour) {
   }
 }
 
+/** veraPDF verdict, with the raw report kept for Forme Review. */
+function veraKept(vera, pdfPath, flavour) {
+  const { pass, xml } = veraValidate(vera, flavour, pdfPath);
+  keepReport(`facturx-en16931.${flavour}.xml`, xml);
+  return pass;
+}
+
 function mustangValid(jar, pdfPath) {
   try {
     const out = execFileSync(
@@ -88,15 +95,18 @@ async function main() {
 
   const xml = readFileSync(XML_PATH);
   const pdf = await renderDocument(invoiceDoc(), { facturX: { xml, profile: 'EN 16931' } });
-  const outDir = mkdtempSync(join(tmpdir(), 'forme-einvoice-gate-'));
+  // With OUT_DIR the invoice joins the Forme Review corpus and its verdicts ride along.
+  const outDir = process.env.OUT_DIR ? (mkdirSync(process.env.OUT_DIR, { recursive: true }), process.env.OUT_DIR) : mkdtempSync(join(tmpdir(), 'forme-einvoice-gate-'));
   const pdfPath = join(outDir, 'facturx-en16931.pdf');
   writeFileSync(pdfPath, pdf);
 
   const checks = [
-    { id: 'verapdf-3b', label: 'veraPDF PDF/A-3b', pass: veraCompliant(vera, pdfPath, '3b') },
-    { id: 'verapdf-ua1', label: 'veraPDF PDF/UA-1', pass: veraCompliant(vera, pdfPath, 'ua1') },
+    { id: 'verapdf-3b', label: 'veraPDF PDF/A-3b', pass: veraKept(vera, pdfPath, '3b') },
+    { id: 'verapdf-ua1', label: 'veraPDF PDF/UA-1', pass: veraKept(vera, pdfPath, 'ua1') },
   ];
   const mustang = mustangValid(jar, pdfPath);
+  // Mustang goes through the documented JSON shape: Forme Review parses veraPDF and nothing else.
+  keepReport('facturx-en16931.mustang.json', JSON.stringify(mustangToConformance(mustang.report, { documentPath: pdfPath, jarPath: jar, file: 'reports/facturx-en16931.mustang.json' }), null, 2));
   checks.push({ id: 'mustang', label: 'Mustang (ZUGFeRD/Factur-X reference validator)', pass: mustang.valid });
 
   // Evidence first (the JSON section is the source; console is a render).

--- a/scripts/verify-pdfua.mjs
+++ b/scripts/verify-pdfua.mjs
@@ -14,11 +14,11 @@
 
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { basename, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 
-import { emitSection, veraValidate, veraVersion } from './parity/lib.mjs';
+import { emitSection, keepReport, veraValidate, veraVersion } from './parity/lib.mjs';
 
 import { serialize } from '@formepdf/react';
 import { getTemplate } from '@formepdf/templates';
@@ -193,7 +193,8 @@ async function main() {
     render: 'pdfUa + tagged + fonts-standard',
     corpus: corpus.map((c) => c.label),
     results: corpus.map((c) => {
-      const { pass, failedClauses } = veraValidate(vera, 'ua1', c.path);
+      const { pass, failedClauses, xml } = veraValidate(vera, 'ua1', c.path);
+      keepReport(`${basename(c.path, '.pdf')}.ua1.xml`, xml); // for Forme Review's --conformance
       return { fixture: c.label, profile: 'ua1', pass, failedClauses };
     }),
   };


### PR DESCRIPTION
The UA-1 gate keeps each veraPDF report under `dist/review/reports`; the e-invoice gate writes its Factur-X PDF into the corpus, keeps its veraPDF reports (PDF/A-3b, PDF/UA-1), and turns Mustang's report into the documented `forme-review-conformance/1` JSON. The upload step moves after the e-invoice gate and attaches `dist/review/reports/*`, on pdf-testkit 0.3.0.

Forme Review parses veraPDF and nothing else, by policy; Mustang, which this repo runs itself, goes through the JSON like any other validator. The adapter is `mustangToConformance` in `scripts/parity/lib.mjs`, about forty lines. Verified locally: a real Mustang 2.26.0 report round-trips through the pdf-testkit 0.3.0 parser with its failures and version, and a kept veraPDF report parses with the file path intact.

After this, every run carries a PDF/UA-1 verdict on all 39 documents, and PDF/A-3b, PDF/UA-1 and EN 16931 verdicts on the Factur-X invoice, each attributed to the validator that produced it. Forme Review records them; it does not validate, and a verdict never changes the check.