### PR TITLE
CI: write a Forme layout sidecar beside every rendered PDF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "forme",
+  "name": "forme-layout",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@pdf-testkit/cli": "^0.3.0",
+        "@pdf-testkit/cli": "^0.4.0",
         "miniflare": "4.20260730.0",
         "puppeteer-core": "25.10.0",
         "sharp": "0.34.4"
@@ -2653,15 +2653,15 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/cli": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.3.0.tgz",
-      "integrity": "sha512-PASZN2T9JXWbAT9XPtgacrrxY1B8Ac9lkwmFlBc3pebvlVIkGQWb6qIrnpx3bRk6aTraGZRUA4rEKgXkonPBZQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.4.0.tgz",
+      "integrity": "sha512-/yNj7E44+5WiZOrfv6GH5pkWlcOHdUj5AVUt5dcZJVUBhjNeXqt06VIEmckpceR0gt7LEuLHhu+hO4MRHyF6ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.3.0",
-        "@pdf-testkit/matcher-core": "^0.3.0",
-        "@pdf-testkit/protocol": "^0.3.0",
+        "@pdf-testkit/core": "^0.4.0",
+        "@pdf-testkit/matcher-core": "^0.4.0",
+        "@pdf-testkit/protocol": "^0.4.0",
         "commander": "^12.1.0",
         "pdfjs-dist": "^4.10.38"
       },
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/@pdf-testkit/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-FHrF99ZELG1TWJv8OoQ2VIQOQUsXHoHg6DxIINTmqshcLzM5psK42/zIBcCmrjaDvo7v47+3Lv8OOwqhZr4qsA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-2JOOO1A/ROZX5GDOF0msfJ0uSmFac21kEKYylAdKIM7gPxHBXKH9DDM/su6NG0s4MCCIn6kvulGNHwIynlkftg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2689,19 +2689,19 @@
       }
     },
     "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.3.0.tgz",
-      "integrity": "sha512-py5wuPgyXVWBBgFSQuU7VJS3ePsOWuU/DHOs5NQb2rg/itKjKLQWGZJGvmhtXuNjrwRHxGjDtactiCXvm8DMSQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.4.0.tgz",
+      "integrity": "sha512-c3gTotTdvi3HL7l2w2YnPPWuINZmPFQNq2NnQJhslViJHgJbIW3qrzybPaelAe/fxa/OhwkQhDESwwA8YvRkDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.3.0"
+        "@pdf-testkit/core": "^0.4.0"
       }
     },
     "node_modules/@pdf-testkit/protocol": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.3.0.tgz",
-      "integrity": "sha512-9LLLCRMhb0QunVEpMOK8UwxE9K6XmbUg129B1/NLuobjEGZ9bRODL84P9bVjVI1ms9Y5X6S2C+QbiJCf+Cr4/w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.4.0.tgz",
+      "integrity": "sha512-HzHx5wufEozYhUkODjZVpQ0yZjEPBvpO6lHmpy8E0EMh+Sr445FnsCscpr29bob+2l6uumHwXdYHi39LfUCNqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2709,14 +2709,14 @@
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.3.0.tgz",
-      "integrity": "sha512-HLs2PF4itpOTchC18GhUaV5PfnuiU5a2J1f7kLghSbQEF/CBpi3brFKnKAL//iC439vHGgyRO691XIr1XyQnSQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.4.0.tgz",
+      "integrity": "sha512-XWNuqMhs66qWZ1JVGlqH+M+mFv0ZHXeBrGOI+N+O/LVlu77ugJvO/WBpMFFI3JAKyPU8RyDemz4yLr5B+vUvYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.3.0",
-        "@pdf-testkit/matcher-core": "^0.3.0"
+        "@pdf-testkit/core": "^0.4.0",
+        "@pdf-testkit/matcher-core": "^0.4.0"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -8969,7 +8969,7 @@
         "@formepdf/fonts-standard": "0.21.0",
         "@formepdf/html": "^0.21.0",
         "@formepdf/templates": "0.21.0",
-        "@pdf-testkit/vitest": "^0.3.0",
+        "@pdf-testkit/vitest": "^0.4.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@pdf-testkit/cli": "^0.4.0",
+        "@pdf-testkit/cli": "^0.4.1",
         "miniflare": "4.20260730.0",
         "puppeteer-core": "25.10.0",
         "sharp": "0.34.4"
@@ -2653,15 +2653,15 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.4.0.tgz",
-      "integrity": "sha512-/yNj7E44+5WiZOrfv6GH5pkWlcOHdUj5AVUt5dcZJVUBhjNeXqt06VIEmckpceR0gt7LEuLHhu+hO4MRHyF6ZQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.4.1.tgz",
+      "integrity": "sha512-toFmup736719jg0sTK8JC665GT/HG8oeq017buodNPt77qrbGb4Azwg8ThBACSQI2HOSfNXHuvnsHzznbWmwZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.0",
-        "@pdf-testkit/matcher-core": "^0.4.0",
-        "@pdf-testkit/protocol": "^0.4.0",
+        "@pdf-testkit/core": "^0.4.1",
+        "@pdf-testkit/matcher-core": "^0.4.1",
+        "@pdf-testkit/protocol": "^0.4.1",
         "commander": "^12.1.0",
         "pdfjs-dist": "^4.10.38"
       },
@@ -2670,9 +2670,9 @@
       }
     },
     "node_modules/@pdf-testkit/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-2JOOO1A/ROZX5GDOF0msfJ0uSmFac21kEKYylAdKIM7gPxHBXKH9DDM/su6NG0s4MCCIn6kvulGNHwIynlkftg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-r9umP9h1d6FMduFIxL0Z1Vu1d1OQjl5Bmyws84/Lnti1o8inLgGvzeco8doG3c4Ww2z46C5kYBSdMYg9BR7TzA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2689,19 +2689,19 @@
       }
     },
     "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.4.0.tgz",
-      "integrity": "sha512-c3gTotTdvi3HL7l2w2YnPPWuINZmPFQNq2NnQJhslViJHgJbIW3qrzybPaelAe/fxa/OhwkQhDESwwA8YvRkDQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.4.1.tgz",
+      "integrity": "sha512-y+ez0aBOIlGskkljX0KHvYbloemPK3lW5oISGQy6nfKzotD0zzEC3YNoSjUvzWO7cAgcsjVMYlZIaX0NYg64iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.0"
+        "@pdf-testkit/core": "^0.4.1"
       }
     },
     "node_modules/@pdf-testkit/protocol": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.4.0.tgz",
-      "integrity": "sha512-HzHx5wufEozYhUkODjZVpQ0yZjEPBvpO6lHmpy8E0EMh+Sr445FnsCscpr29bob+2l6uumHwXdYHi39LfUCNqA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.4.1.tgz",
+      "integrity": "sha512-6XH7mzLdBo72nw1YZCxqGNF5Tk2r4oFfsSvDd55cAEcty6NEcm9DDu0bV8d42WXOxRPBZgCF7gU/Wj91FVQ2zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2709,14 +2709,14 @@
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.4.0.tgz",
-      "integrity": "sha512-XWNuqMhs66qWZ1JVGlqH+M+mFv0ZHXeBrGOI+N+O/LVlu77ugJvO/WBpMFFI3JAKyPU8RyDemz4yLr5B+vUvYQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.4.1.tgz",
+      "integrity": "sha512-QwI6bCGz1RjF3xfVBiC3kUJmWAxpd14nYa87QaNKaX5gutCZHaflohoSoveh8OXsHakw08Td0fEi+XmGm3qIsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.0",
-        "@pdf-testkit/matcher-core": "^0.4.0"
+        "@pdf-testkit/core": "^0.4.1",
+        "@pdf-testkit/matcher-core": "^0.4.1"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -8969,7 +8969,7 @@
         "@formepdf/fonts-standard": "0.21.0",
         "@formepdf/html": "^0.21.0",
         "@formepdf/templates": "0.21.0",
-        "@pdf-testkit/vitest": "^0.4.0",
+        "@pdf-testkit/vitest": "^0.4.1",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@pdf-testkit/cli": "^0.4.0",
+    "@pdf-testkit/cli": "^0.4.1",
     "miniflare": "4.20260730.0",
     "puppeteer-core": "25.10.0",
     "sharp": "0.34.4"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@pdf-testkit/cli": "^0.3.0",
+    "@pdf-testkit/cli": "^0.4.0",
     "miniflare": "4.20260730.0",
     "puppeteer-core": "25.10.0",
     "sharp": "0.34.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.21.0",
     "@formepdf/html": "^0.21.0",
-    "@pdf-testkit/vitest": "^0.4.0",
+    "@pdf-testkit/vitest": "^0.4.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.21.0",
     "@formepdf/html": "^0.21.0",
-    "@pdf-testkit/vitest": "^0.3.0",
+    "@pdf-testkit/vitest": "^0.4.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/core/tests/__pdf_snapshots__/templates-demo.regression.test-demo-grid-dashboard.json
+++ b/packages/core/tests/__pdf_snapshots__/templates-demo.regression.test-demo-grid-dashboard.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "producer": "formepdf",
-  "createdAt": "2026-09-02T01:54:52.708Z",
+  "createdAt": "2026-09-09T12:25:16.605Z",
   "pageCount": 1,
   "pages": [
     {
@@ -71,17 +71,17 @@
         "0:container:27",
         "0:container:28",
         "0:container:29",
-        "0:text:22",
         "0:container:30",
+        "0:text:22",
         "0:container:31",
-        "0:text:23",
         "0:container:32",
-        "0:text:24",
+        "0:text:23",
         "0:container:33",
-        "0:text:25",
         "0:container:34",
+        "0:text:24",
         "0:container:35",
         "0:container:36",
+        "0:text:25",
         "0:container:37",
         "0:container:38",
         "0:container:39",
@@ -663,7 +663,7 @@
         "x": 40,
         "y": 221.4,
         "width": 532,
-        "height": 204.2
+        "height": 195.8
       },
       "order": 23,
       "parentId": null,
@@ -687,7 +687,7 @@
         "x": 40,
         "y": 221.4,
         "width": 258,
-        "height": 204.2
+        "height": 195.8
       },
       "order": 24,
       "parentId": "0:container:8",
@@ -1407,7 +1407,7 @@
         "x": 57,
         "y": 391.8,
         "width": 224,
-        "height": 16.8
+        "height": 8.4
       },
       "order": 54,
       "parentId": "0:container:9",
@@ -1428,13 +1428,37 @@
       "role": "container",
       "pageIndex": 0,
       "bbox": {
-        "x": 91,
+        "x": 79,
         "y": 391.8,
-        "width": 41.3,
-        "height": 16.8
+        "width": 47.3,
+        "height": 8.4
       },
       "order": 55,
       "parentId": "0:container:28",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:30",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 79,
+        "y": 393,
+        "width": 6,
+        "height": 6
+      },
+      "order": 56,
+      "parentId": "0:container:29",
       "text": null,
       "normText": null,
       "font": {
@@ -1452,12 +1476,12 @@
       "role": "text",
       "pageIndex": 0,
       "bbox": {
-        "x": 99.2,
+        "x": 88,
         "y": 391.8,
-        "width": 33.2,
-        "height": 16.8
+        "width": 38.3,
+        "height": 8.4
       },
-      "order": 56,
+      "order": 57,
       "parentId": "0:container:29",
       "text": "North America",
       "normText": "north america",
@@ -1472,16 +1496,16 @@
       "confidence": 1
     },
     {
-      "id": "0:container:30",
+      "id": "0:container:31",
       "role": "container",
       "pageIndex": 0,
       "bbox": {
-        "x": 140.3,
+        "x": 134.3,
         "y": 391.8,
-        "width": 22.4,
-        "height": 16.8
+        "width": 28.4,
+        "height": 8.4
       },
-      "order": 57,
+      "order": 58,
       "parentId": "0:container:28",
       "text": null,
       "normText": null,
@@ -1496,17 +1520,17 @@
       "confidence": 1
     },
     {
-      "id": "0:container:31",
+      "id": "0:container:32",
       "role": "container",
       "pageIndex": 0,
       "bbox": {
-        "x": 140.3,
+        "x": 134.3,
         "y": 393,
-        "width": 4.6,
+        "width": 6,
         "height": 6
       },
-      "order": 58,
-      "parentId": "0:container:30",
+      "order": 59,
+      "parentId": "0:container:31",
       "text": null,
       "normText": null,
       "font": {
@@ -1524,13 +1548,13 @@
       "role": "text",
       "pageIndex": 0,
       "bbox": {
-        "x": 147.9,
+        "x": 143.3,
         "y": 391.8,
-        "width": 19.3,
+        "width": 19.4,
         "height": 8.4
       },
-      "order": 59,
-      "parentId": "0:container:30",
+      "order": 60,
+      "parentId": "0:container:31",
       "text": "Europe",
       "normText": "europe",
       "font": {
@@ -1544,17 +1568,41 @@
       "confidence": 1
     },
     {
-      "id": "0:container:32",
+      "id": "0:container:33",
       "role": "container",
       "pageIndex": 0,
       "bbox": {
         "x": 170.7,
         "y": 391.8,
-        "width": 34,
-        "height": 16.8
+        "width": 40,
+        "height": 8.4
       },
-      "order": 60,
+      "order": 61,
       "parentId": "0:container:28",
+      "text": null,
+      "normText": null,
+      "font": {
+        "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:container:34",
+      "role": "container",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 170.7,
+        "y": 393,
+        "width": 6,
+        "height": 6
+      },
+      "order": 62,
+      "parentId": "0:container:33",
       "text": null,
       "normText": null,
       "font": {
@@ -1572,13 +1620,13 @@
       "role": "text",
       "pageIndex": 0,
       "bbox": {
-        "x": 178.7,
+        "x": 179.7,
         "y": 391.8,
-        "width": 26,
-        "height": 16.8
+        "width": 31,
+        "height": 8.4
       },
-      "order": 61,
-      "parentId": "0:container:32",
+      "order": 63,
+      "parentId": "0:container:33",
       "text": "Asia Pacific",
       "normText": "asia pacific",
       "font": {
@@ -1592,89 +1640,17 @@
       "confidence": 1
     },
     {
-      "id": "0:container:33",
-      "role": "container",
-      "pageIndex": 0,
-      "bbox": {
-        "x": 212.7,
-        "y": 391.8,
-        "width": 34.4,
-        "height": 16.8
-      },
-      "order": 62,
-      "parentId": "0:container:28",
-      "text": null,
-      "normText": null,
-      "font": {
-        "size": 12,
-        "weight": 400,
-        "family": "Helvetica",
-        "italic": false
-      },
-      "headingLevel": null,
-      "overflow": null,
-      "confidence": 1
-    },
-    {
-      "id": "0:text:25",
-      "role": "text",
-      "pageIndex": 0,
-      "bbox": {
-        "x": 220.7,
-        "y": 391.8,
-        "width": 26.3,
-        "height": 16.8
-      },
-      "order": 63,
-      "parentId": "0:container:33",
-      "text": "Middle East",
-      "normText": "middle east",
-      "font": {
-        "size": 6,
-        "weight": 400,
-        "family": "Helvetica",
-        "italic": false
-      },
-      "headingLevel": null,
-      "overflow": null,
-      "confidence": 1
-    },
-    {
-      "id": "0:container:34",
-      "role": "container",
-      "pageIndex": 0,
-      "bbox": {
-        "x": 91,
-        "y": 397.2,
-        "width": 5.2,
-        "height": 6
-      },
-      "order": 64,
-      "parentId": "0:container:29",
-      "text": null,
-      "normText": null,
-      "font": {
-        "size": 12,
-        "weight": 400,
-        "family": "Helvetica",
-        "italic": false
-      },
-      "headingLevel": null,
-      "overflow": null,
-      "confidence": 1
-    },
-    {
       "id": "0:container:35",
       "role": "container",
       "pageIndex": 0,
       "bbox": {
-        "x": 170.7,
-        "y": 397.2,
-        "width": 5,
-        "height": 6
+        "x": 218.7,
+        "y": 391.8,
+        "width": 40.4,
+        "height": 8.4
       },
-      "order": 65,
-      "parentId": "0:container:32",
+      "order": 64,
+      "parentId": "0:container:28",
       "text": null,
       "normText": null,
       "font": {
@@ -1692,17 +1668,41 @@
       "role": "container",
       "pageIndex": 0,
       "bbox": {
-        "x": 212.7,
-        "y": 397.2,
-        "width": 5,
+        "x": 218.7,
+        "y": 393,
+        "width": 6,
         "height": 6
       },
-      "order": 66,
-      "parentId": "0:container:33",
+      "order": 65,
+      "parentId": "0:container:35",
       "text": null,
       "normText": null,
       "font": {
         "size": 12,
+        "weight": 400,
+        "family": "Helvetica",
+        "italic": false
+      },
+      "headingLevel": null,
+      "overflow": null,
+      "confidence": 1
+    },
+    {
+      "id": "0:text:25",
+      "role": "text",
+      "pageIndex": 0,
+      "bbox": {
+        "x": 227.7,
+        "y": 391.8,
+        "width": 31.4,
+        "height": 8.4
+      },
+      "order": 66,
+      "parentId": "0:container:35",
+      "text": "Middle East",
+      "normText": "middle east",
+      "font": {
+        "size": 6,
         "weight": 400,
         "family": "Helvetica",
         "italic": false
@@ -1717,7 +1717,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 40,
-        "y": 445.6,
+        "y": 437.2,
         "width": 532,
         "height": 246
       },
@@ -1741,7 +1741,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 40,
-        "y": 445.6,
+        "y": 437.2,
         "width": 259,
         "height": 110
       },
@@ -1765,7 +1765,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 313,
-        "y": 445.6,
+        "y": 437.2,
         "width": 259,
         "height": 110
       },
@@ -1789,7 +1789,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 55,
-        "y": 460.6,
+        "y": 452.2,
         "width": 229,
         "height": 14
       },
@@ -1813,7 +1813,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 328,
-        "y": 460.6,
+        "y": 452.2,
         "width": 229,
         "height": 14
       },
@@ -1837,7 +1837,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 55,
-        "y": 480.6,
+        "y": 472.2,
         "width": 229,
         "height": 60
       },
@@ -1861,7 +1861,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 328,
-        "y": 480.6,
+        "y": 472.2,
         "width": 229,
         "height": 60
       },
@@ -1885,7 +1885,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 40,
-        "y": 569.6,
+        "y": 561.2,
         "width": 259,
         "height": 122
       },
@@ -1909,7 +1909,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 313,
-        "y": 569.6,
+        "y": 561.2,
         "width": 259,
         "height": 122
       },
@@ -1933,7 +1933,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 55,
-        "y": 584.6,
+        "y": 576.2,
         "width": 229,
         "height": 14
       },
@@ -1957,7 +1957,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 328,
-        "y": 584.6,
+        "y": 576.2,
         "width": 229,
         "height": 14
       },
@@ -1981,7 +1981,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 55,
-        "y": 604.6,
+        "y": 596.2,
         "width": 229,
         "height": 72
       },
@@ -2005,7 +2005,7 @@
       "pageIndex": 0,
       "bbox": {
         "x": 328,
-        "y": 604.6,
+        "y": 596.2,
         "width": 229,
         "height": 72
       },
@@ -2120,5 +2120,5 @@
       "confidence": 1
     }
   ],
-  "contentHash": "sha256:e51d6af09e7c0f047f0fb82cd1bcfe9ac46093f3f48d08f0b9f320621aa54cf6"
+  "contentHash": "sha256:be0bf35e5a490ba0c1d708bdb2923a7b3b71eca1e7316a855b7369e6a36e4b52"
 }

--- a/scripts/parity/lib.mjs
+++ b/scripts/parity/lib.mjs
@@ -5,8 +5,10 @@
 // and renders its human console output FROM that same object — never a parallel
 // print path that could disagree with the emitted evidence.
 
-import { writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 
 /** Write a partial section `<PARITY_DIR>/<name>.json` when PARITY_DIR is set. */
@@ -65,6 +67,30 @@ export function veraValidate(vera, flavour, pdfPath) {
  * it (`--conformance`). No-op unless OUT_DIR is set. The report names the PDF
  * by its path under OUT_DIR, which is also the path the upload names it by.
  */
+/**
+ * Write the layout Forme returned with a PDF beside it as
+ * `<file>.pdf.layout.json`, the sidecar pdf-testkit's upload reads to take
+ * structure from the layout (confidence 1) instead of inferring it from the
+ * PDF with pdfjs. Carries the PDF's sha256 so a stale sidecar is refused.
+ * No-op unless OUT_DIR is set, like `keepReport`.
+ */
+export function keepLayout(pdfPath, pdf, layout, producer) {
+  if (!process.env.OUT_DIR) return null;
+  const p = `${pdfPath}.layout.json`;
+  writeFileSync(p, JSON.stringify({ format: 'forme-layout/1', pdf_sha256: createHash('sha256').update(pdf).digest('hex'), producer: { name: producer, version: formeVersion(producer) }, layout }));
+  return p;
+}
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+/** The version of a workspace package, for the sidecar's producer stamp. */
+export function formeVersion(pkg) {
+  try {
+    return JSON.parse(readFileSync(resolve(REPO_ROOT, 'packages', pkg.replace(/^@formepdf\//, ''), 'package.json'), 'utf8')).version;
+  } catch {
+    return 'unknown';
+  }
+}
+
 export function keepReport(name, text) {
   const dir = process.env.OUT_DIR;
   if (!dir) return null;

--- a/scripts/verify-einvoice.mjs
+++ b/scripts/verify-einvoice.mjs
@@ -18,7 +18,7 @@
 // PARITY_DIR: also emit the structured evidence section.
 
 import { execFileSync } from 'node:child_process';
-import { emitSection, keepReport, mustangToConformance, veraValidate } from './parity/lib.mjs';
+import { emitSection, keepLayout, keepReport, mustangToConformance, veraValidate } from './parity/lib.mjs';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -26,7 +26,7 @@ import { fileURLToPath } from 'node:url';
 import React from 'react';
 import { Document, Page, View, Text, Font } from '@formepdf/react';
 import { standardFonts } from '@formepdf/fonts-standard';
-import { renderDocument } from '@formepdf/core';
+import { renderDocumentWithLayout } from '@formepdf/core';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const XML_PATH = join(HERE, '..', 'engine', 'tests', 'fixtures', 'einvoice', 'EN16931_Einfach.cii.xml');
@@ -84,11 +84,12 @@ async function main() {
   }
 
   const xml = readFileSync(XML_PATH);
-  const pdf = await renderDocument(invoiceDoc(), { facturX: { xml, profile: 'EN 16931' } });
+  const { pdf, layout } = await renderDocumentWithLayout(invoiceDoc(), { facturX: { xml, profile: 'EN 16931' } });
   // With OUT_DIR the invoice joins the Forme Review corpus and its verdicts ride along.
   const outDir = process.env.OUT_DIR ? (mkdirSync(process.env.OUT_DIR, { recursive: true }), process.env.OUT_DIR) : mkdtempSync(join(tmpdir(), 'forme-einvoice-gate-'));
   const pdfPath = join(outDir, 'facturx-en16931.pdf');
   writeFileSync(pdfPath, pdf);
+  keepLayout(pdfPath, pdf, layout, '@formepdf/core');
 
   const checks = [
     { id: 'verapdf-3b', label: 'veraPDF PDF/A-3b', pass: veraKept(vera, pdfPath, '3b') },

--- a/scripts/verify-pdfua.mjs
+++ b/scripts/verify-pdfua.mjs
@@ -18,7 +18,7 @@ import { basename, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 
-import { emitSection, keepReport, veraValidate, veraVersion } from './parity/lib.mjs';
+import { emitSection, keepLayout, keepReport, veraValidate, veraVersion } from './parity/lib.mjs';
 
 import { serialize } from '@formepdf/react';
 import { getTemplate } from '@formepdf/templates';
@@ -31,7 +31,7 @@ import {
 } from '@formepdf/templates/schemas';
 import { standardFonts } from '@formepdf/fonts-standard';
 import { renderPdfWithLayout } from '@formepdf/core';
-import { renderHtml } from '@formepdf/html';
+import { renderHtmlWithLayout } from '@formepdf/html';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = join(HERE, '..');
@@ -107,8 +107,8 @@ async function renderNorthmoor(name) {
   const html = (await readFile(join(dir, 'index.html'), 'utf8'))
     .replace('<link rel="stylesheet" href="../northmoor-shared.css">', `<style>${shared}</style>`)
     .replace('<link rel="stylesheet" href="style.css">', `<style>${own}</style>`);
-  const { pdf, warnings } = renderHtml(html, { pdfUa: true, lang: LANG, fonts: HTML_FONTS });
-  return { pdf, warnings };
+  const { pdf, warnings, layout } = renderHtmlWithLayout(html, { pdfUa: true, lang: LANG, fonts: HTML_FONTS });
+  return { pdf, warnings, layout, producer: '@formepdf/html' };
 }
 
 async function renderTemplate(name, data) {
@@ -117,14 +117,14 @@ async function renderTemplate(name, data) {
   doc.tagged = true;
   doc.metadata = { ...(doc.metadata ?? {}), lang: LANG };
   doc.fonts = CORE_FONTS;
-  const { pdf, warnings } = await renderPdfWithLayout(JSON.stringify(doc));
-  return { pdf, warnings };
+  const { pdf, warnings, layout } = await renderPdfWithLayout(JSON.stringify(doc));
+  return { pdf, warnings, layout, producer: '@formepdf/core' };
 }
 
 async function renderFixture(name) {
   const html = await readFile(join(FIXTURES, `${name}.html`), 'utf8');
-  const { pdf, warnings } = renderHtml(html, { pdfUa: true, lang: LANG, fonts: HTML_FONTS });
-  return { pdf, warnings };
+  const { pdf, warnings, layout } = renderHtmlWithLayout(html, { pdfUa: true, lang: LANG, fonts: HTML_FONTS });
+  return { pdf, warnings, layout, producer: '@formepdf/html' };
 }
 
 function findVeraPdf() {
@@ -141,21 +141,24 @@ async function main() {
 
   console.log('Rendering PDF/UA-1 corpus…');
   for (const [name, data] of Object.entries(TEMPLATES)) {
-    const { pdf, warnings } = await renderTemplate(name, data);
+    const { pdf, warnings, layout, producer } = await renderTemplate(name, data);
     const p = join(outDir, `template-${name}.pdf`);
     writeFileSync(p, pdf);
+    keepLayout(p, pdf, layout, producer);
     corpus.push({ label: `template/${name}`, path: p, warnings });
   }
   for (const name of HTML_FIXTURES) {
-    const { pdf, warnings } = await renderFixture(name);
+    const { pdf, warnings, layout, producer } = await renderFixture(name);
     const p = join(outDir, `html-${name}.pdf`);
     writeFileSync(p, pdf);
+    keepLayout(p, pdf, layout, producer);
     corpus.push({ label: `html/${name}`, path: p, warnings });
   }
   for (const name of NORTHMOOR) {
-    const { pdf, warnings } = await renderNorthmoor(name);
+    const { pdf, warnings, layout, producer } = await renderNorthmoor(name);
     const p = join(outDir, `northmoor-${name}.pdf`);
     writeFileSync(p, pdf);
+    keepLayout(p, pdf, layout, producer);
     corpus.push({ label: `northmoor/${name}`, path: p, warnings });
   }
 


### PR DESCRIPTION
Every PDF the review corpus renders now gets `<file>.pdf.layout.json` beside it: the layout Forme returned with the PDF, the PDF's sha256, and the producing package and version. pdf-testkit's upload reads the sidecar when its hash matches and takes structure from the layout at confidence 1, instead of inferring it from the PDF with pdfjs. Until now every document in Forme Review, Forme's own included, was measured on the pdfjs path.

The UA corpus switches to `renderHtmlWithLayout` and keeps the layout `renderPdfWithLayout` already returned; the e-invoice gate switches to `renderDocumentWithLayout`. Nothing else in the workflow changes: the upload step's glob is unchanged and the CLI finds the sidecars itself.

Verified locally: 40 sidecars written, every hash matching, and the 0.4.0 CLI takes all 40 documents from the layout (235ms) where `--no-layout` takes them from pdfjs (1,037ms).

Sidecar support ships in pdf-testkit 0.4.0. A second commit will bump `@pdf-testkit/cli` once it is published; until then the 0.3.0 CLI ignores the sidecars and this branch behaves exactly as main.