### PR TITLE
feat(preview): @formepdf/preview — byte-true in-browser PDF preview + CI parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,17 @@ jobs:
       - name: Test Renderer
         working-directory: packages/renderer
         run: npm test
+      - name: Test Preview (parity gate)
+        # @formepdf/preview's promise is that what the browser shows equals what
+        # the server produces. This runs its parity suite — renderForPreview
+        # through the /worker (browser-proxy) entry vs the Node entry, asserted
+        # BYTE-IDENTICAL across an inline corpus incl. the 2-pass page-counter
+        # path. Divergence here would be silent in production (the preview would
+        # just start disagreeing with output), so it must fail the build. Needs
+        # only the HTML WASM (built above, all three targets) and
+        # @formepdf/fonts-standard (built above).
+        working-directory: packages/preview
+        run: npm test
       - name: Test CLI
         working-directory: packages/cli
         run: npm test

--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -1,0 +1,102 @@
+# @formepdf/preview
+
+In-browser PDF preview for [Forme](https://formepdf.com). It renders your HTML
+through the **same engine your server uses** and shows the **actual PDF** in an
+iframe — so the preview and the produced file agree by construction, not by
+approximation.
+
+```tsx
+import { FormePreview, standardFonts } from '@formepdf/preview';
+
+// The SAME options object you pass to your server's renderHtml.
+const options = { fonts: standardFonts() };
+
+<FormePreview html={html} options={options} style={{ height: 600 }} />
+```
+
+## Read this first: bundle cost
+
+This component renders in the browser, which means it loads the Forme WASM
+engine — **~7.7 MB**, fetched on first preview (lazily, so it's not in your
+initial bundle; cached by the browser thereafter). That is the unavoidable cost
+of rendering-in-browser: it's what buys you a preview that can't disagree with
+your server. If you only need to *show* a server-produced PDF and don't need
+live in-browser rendering, you don't need this package — point an `<iframe>` at
+your server's PDF.
+
+## Why it agrees with your output
+
+Three things could make a preview diverge from the produced PDF. This component
+closes all three:
+
+- **Display.** It shows the real PDF bytes in the browser's native viewer (blob
+  → iframe) — no canvas rasterizer approximating the file. What you see is the
+  file, in the same viewer your recipient opens.
+- **Options.** There is no `previewOptions`. You pass the *same* `options`
+  object to `<FormePreview>` and to your server's `renderHtml`. One
+  configuration can't drift from itself.
+- **Fonts.** See below — the one that bites silently.
+
+## The font-parity contract
+
+The silent failure: a template references a font the **server** embeds but the
+**preview** doesn't, so each side renders differently with *no error*. Forme's
+browser render path cannot fetch fonts — it takes bytes — so:
+
+1. **Express fonts as bytes, once, for both sides.** Use `standardFonts()` for
+   the embeddable base-14 replacements, or pass your own
+   `{ family, data: Uint8Array | base64, weight, italic }`. Hand the same array
+   to your server `renderHtml` and to `<FormePreview options>`.
+2. **Make a mismatch loud.** Fingerprint what the server was given and pass it
+   in; the preview shows a banner if the fonts it holds don't match:
+
+   ```tsx
+   import { fontFingerprint } from '@formepdf/preview';
+   const print = fontFingerprint(options.fonts);   // compute where you build server options
+   <FormePreview html={html} options={options} expectedFontFingerprint={print} />
+   ```
+
+## Bundler setup
+
+The engine is self-instantiating WASM, so your bundler needs WASM + top-level
+await support. For Vite:
+
+```ts
+// vite.config.ts
+import wasm from 'vite-plugin-wasm';
+import topLevelAwait from 'vite-plugin-top-level-await';
+export default { plugins: [wasm(), topLevelAwait()] };
+```
+
+(Framework equivalents exist for webpack/Next/etc.)
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `html` | `string` | The document HTML — same string you render server-side. |
+| `options` | `RenderHtmlOptions` | **The same object you pass to the server.** Keep it referentially stable (memoize). |
+| `expectedFontFingerprint` | `string?` | Server's `fontFingerprint(fonts)`; shows a banner on mismatch. |
+| `debounceMs` | `number?` | Debounce before re-render (default 150ms), for live-edit. |
+| `onWarnings` | `(warnings: string[]) => void` | Engine warnings (missing PDF/UA fonts, dropped content, …) — never silent. |
+| `onError` / `onRender` | callbacks | Error, and `{ passes, warnings, bytes }` on success. |
+| `className` / `style` / `title` | — | Sizes and labels the iframe container. |
+
+## What it does NOT do
+
+Not an editor. Not an annotating or form-filling viewer. Not a replacement for a
+full PDF viewer, and no toolbar of its own — you get the browser's native PDF
+controls (scroll, zoom, print). It renders the HTML and shows the file, pages in
+order. If you need programmatic zoom or custom page layout, that's a
+canvas-based viewer (a documented approximation) — out of scope for a
+fidelity-first component.
+
+## Notes & caveats
+
+- **v1 is the HTML input path.** JSX/React-element input is planned as a second
+  input; the display and parity story are identical.
+- **`blob:` under a strict CSP** needs `frame-src blob:`.
+- **Environments without a native PDF viewer** (some embedded webviews) won't
+  display the iframe; use `onRender`'s bytes to offer a download instead.
+
+MIT.

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@formepdf/preview",
+  "version": "0.21.0",
+  "description": "In-browser PDF preview for Forme — renders HTML through the same engine as the server and shows the actual PDF, so preview and output agree by construction.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@formepdf/fonts-standard": "^0.21.0",
+    "@formepdf/html": "^0.21.0"
+  },
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/preview/src/FormePreview.tsx
+++ b/packages/preview/src/FormePreview.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+import type { RenderHtmlOptions } from '@formepdf/html';
+import { renderForPreview, fontsMatch } from './render.js';
+import type { PreviewFont, RenderHtmlFn } from './render.js';
+
+export interface FormePreviewProps {
+  /** The document HTML — the same string you POST to your server render. */
+  html: string;
+  /**
+   * Render options — THE SAME object you pass to the server's `renderHtml`.
+   * There is deliberately no `previewOptions`: preview and output agree because
+   * there is one configuration. Should be referentially stable (memoize it).
+   */
+  options?: RenderHtmlOptions;
+  /**
+   * Optional parity check. If you fingerprint the fonts your server was given
+   * (`fontFingerprint(...)`) and pass it here, the preview shows a visible
+   * banner when the fonts it holds don't match — turning a silent font
+   * fall-back into a loud one.
+   */
+  expectedFontFingerprint?: string;
+  /** Debounce before (re)rendering, for live-edit. Default 150ms. */
+  debounceMs?: number;
+  onWarnings?: (warnings: string[]) => void;
+  onError?: (error: Error) => void;
+  onRender?: (info: { passes: number; warnings: string[]; bytes: number }) => void;
+  className?: string;
+  style?: CSSProperties;
+  /** Accessible title for the preview iframe. */
+  title?: string;
+}
+
+// One engine load per app, shared across every <FormePreview>. Lazily imported
+// so the ~7.7MB WASM stays out of the initial bundle and loads on first preview.
+let enginePromise: Promise<RenderHtmlFn> | null = null;
+function loadEngine(): Promise<RenderHtmlFn> {
+  if (!enginePromise) {
+    enginePromise = import('@formepdf/html/browser').then((m) => m.renderHtml as RenderHtmlFn);
+  }
+  return enginePromise;
+}
+
+type Status = 'loading' | 'rendering' | 'ready' | 'error';
+
+/**
+ * Renders `html` through the Forme engine in the browser and shows the ACTUAL
+ * PDF in an iframe (the browser's native viewer). Because it calls the same
+ * `renderHtml` the server calls with the same options, what you see is what the
+ * server produces — parity by construction. It is not a viewer, editor, or
+ * toolbar: it shows what the engine produced, pages in order.
+ */
+export function FormePreview(props: FormePreviewProps): ReactElement {
+  const { html, options, expectedFontFingerprint, debounceMs = 150, className, style, title = 'PDF preview' } = props;
+
+  const [url, setUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>('loading');
+  const [error, setError] = useState<string | null>(null);
+
+  // Latest callbacks without re-triggering the render effect on identity change.
+  const cbs = useRef({ onWarnings: props.onWarnings, onError: props.onError, onRender: props.onRender });
+  cbs.current = { onWarnings: props.onWarnings, onError: props.onError, onRender: props.onRender };
+
+  const versionRef = useRef(0);
+  const urlRef = useRef<string | null>(null);
+
+  const fontMismatch =
+    expectedFontFingerprint != null &&
+    !fontsMatch(options?.fonts as PreviewFont[] | undefined, expectedFontFingerprint);
+
+  useEffect(() => {
+    const version = ++versionRef.current;
+    // Keep the last good frame visible while re-rendering; only show the full
+    // skeleton before the first successful render.
+    setStatus(urlRef.current ? 'rendering' : 'loading');
+    setError(null);
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const renderHtml = await loadEngine();
+          if (version !== versionRef.current) return;
+          const result = await renderForPreview(html, options, renderHtml);
+          if (version !== versionRef.current) return;
+
+          const next = URL.createObjectURL(new Blob([result.pdf as BlobPart], { type: 'application/pdf' }));
+          if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+          urlRef.current = next;
+          setUrl(next);
+          setStatus('ready');
+          cbs.current.onWarnings?.(result.warnings);
+          cbs.current.onRender?.({ passes: result.passes, warnings: result.warnings, bytes: result.pdf.length });
+        } catch (e) {
+          if (version !== versionRef.current) return;
+          const err = e instanceof Error ? e : new Error(String(e));
+          setError(err.message);
+          setStatus('error');
+          cbs.current.onError?.(err);
+        }
+      })();
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+    // `options` should be referentially stable (documented); debounce + the
+    // version guard absorb over-renders if it isn't.
+  }, [html, options, debounceMs]);
+
+  // Revoke the outstanding object URL on unmount.
+  useEffect(() => () => { if (urlRef.current) URL.revokeObjectURL(urlRef.current); }, []);
+
+  return (
+    <div className={className} style={{ position: 'relative', minHeight: 200, ...style }}>
+      {url && (
+        <iframe
+          src={url}
+          title={title}
+          style={{ width: '100%', height: '100%', border: 0, display: 'block' }}
+        />
+      )}
+
+      {fontMismatch && (
+        <div style={bannerStyle('#7c2d12', '#fed7aa')} role="status">
+          Preview fonts differ from the server output — this preview may not match the produced PDF.
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div style={bannerStyle('#7f1d1d', '#fecaca')} role="alert">
+          Render failed: {error}
+        </div>
+      )}
+
+      {(status === 'loading' || status === 'rendering') && (
+        <div style={overlayStyle(status === 'loading')} aria-live="polite">
+          {status === 'loading' ? 'Loading preview…' : 'Rendering…'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function bannerStyle(bg: string, fg: string): CSSProperties {
+  return {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    padding: '6px 10px',
+    background: bg,
+    color: fg,
+    font: '12px/1.4 system-ui, sans-serif',
+    zIndex: 2,
+  };
+}
+
+function overlayStyle(opaque: boolean): CSSProperties {
+  return {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    // 'loading' has no frame behind it → solid; 'rendering' floats over the
+    // last good frame → subtle.
+    background: opaque ? '#fafafa' : 'rgba(250,250,250,0.55)',
+    color: '#52525b',
+    font: '13px/1.4 system-ui, sans-serif',
+    zIndex: 1,
+    pointerEvents: 'none',
+  };
+}

--- a/packages/preview/src/index.ts
+++ b/packages/preview/src/index.ts
@@ -1,0 +1,4 @@
+export { FormePreview } from './FormePreview.js';
+export type { FormePreviewProps } from './FormePreview.js';
+export { renderForPreview, standardFonts, fontFingerprint, fontsMatch } from './render.js';
+export type { PreviewFont, RenderHtmlFn } from './render.js';

--- a/packages/preview/src/render.ts
+++ b/packages/preview/src/render.ts
@@ -44,6 +44,10 @@ export async function renderForPreview(
   options: RenderHtmlOptions | undefined,
   renderHtml: RenderHtmlFn,
 ): Promise<RenderHtmlResult> {
+  // The guarantee is the ABSENCE of transforms. Do NOT add a preview-specific
+  // default, option, or mutation here — any divergence from what the server
+  // passes to renderHtml silently breaks preview↔output parity. The CI parity
+  // gate (browser bytes === server bytes across the corpus) exists to catch it.
   return await renderHtml(html, options);
 }
 

--- a/packages/preview/src/render.ts
+++ b/packages/preview/src/render.ts
@@ -1,0 +1,112 @@
+// The parity core. Kept free of React so it is unit-testable in Node and so the
+// byte-identity guarantee is expressed as a plain function, not a component.
+
+import { standardFonts as liberationFonts } from '@formepdf/fonts-standard';
+import type { RenderHtmlOptions, RenderHtmlResult } from '@formepdf/html';
+
+/**
+ * A font expressed the way `@formepdf/html` wants it: bytes (or base64), never a
+ * path or URL — the browser HTML render path cannot fetch, so bytes are the one
+ * form that renders identically on the server and in the preview.
+ */
+export interface PreviewFont {
+  family: string;
+  /** Raw TTF bytes, or a base64 string. */
+  data: Uint8Array | string;
+  /** CSS weight (400 regular, 700 bold). Default 400. */
+  weight?: number;
+  italic?: boolean;
+}
+
+/** The shape of `renderHtml` from any `@formepdf/html` entry (node/browser/worker). */
+export type RenderHtmlFn = (
+  html: string,
+  options?: RenderHtmlOptions,
+) => RenderHtmlResult | Promise<RenderHtmlResult>;
+
+/**
+ * Render a document for preview.
+ *
+ * This is deliberately a faithful passthrough: it calls the injected
+ * `renderHtml` with the caller's EXACT `(html, options)`. There is no
+ * preview-specific option, default, or transform — that absence is the parity
+ * guarantee. Because the browser component passes the browser `renderHtml` and
+ * the server passes the node one, and this function changes nothing between
+ * them, the preview bytes equal the server bytes. `tests/parity.test.ts` locks
+ * exactly that; if a future change makes this anything more than a passthrough,
+ * the test goes red.
+ *
+ * `renderHtml` is injected rather than imported so this module carries no WASM
+ * and tests can drive it with the Node/worker entry.
+ */
+export async function renderForPreview(
+  html: string,
+  options: RenderHtmlOptions | undefined,
+  renderHtml: RenderHtmlFn,
+): Promise<RenderHtmlResult> {
+  return await renderHtml(html, options);
+}
+
+/**
+ * `@formepdf/fonts-standard` adapted to `renderHtml`'s font shape.
+ *
+ * fonts-standard emits `{ family, src, fontWeight, fontStyle }`; `renderHtml`
+ * wants `{ family, data, weight, italic }`. Hand-mapping this on each side is
+ * exactly where preview and server silently drift, so this is the one blessed
+ * adapter — pass its output to BOTH your server `renderHtml` and `<FormePreview
+ * options>`.
+ */
+export function standardFonts(): PreviewFont[] {
+  return liberationFonts().map((f) => ({
+    family: f.family,
+    data: f.src,
+    weight: f.fontWeight,
+    italic: f.fontStyle === 'italic',
+  }));
+}
+
+/**
+ * A stable, order-independent, content-sensitive fingerprint of a font set.
+ *
+ * The point is to make the silent failure loud: a template referencing a font
+ * that the server embeds but the preview doesn't renders one way on each side
+ * with no error. Fingerprint the fonts you hand each side; if the prints
+ * differ, the preview cannot be trusted to match — surface it. Equal set,
+ * any order → equal print; a different family/weight/style OR different bytes →
+ * different print. Undefined and empty are the same, stable value.
+ */
+export function fontFingerprint(fonts?: PreviewFont[]): string {
+  if (!fonts || fonts.length === 0) return 'fonts:0';
+  const lines = fonts
+    .map((f) => `${f.family}|${f.weight ?? 400}|${f.italic ? 'i' : 'n'}|${hash(toBytes(f.data))}`)
+    .sort();
+  return `fonts:${fonts.length}:${hash(toBytes(lines.join('\n')))}`;
+}
+
+/**
+ * Do these fonts match what the other side was given? A convenience over
+ * `fontFingerprint` for the component's mismatch banner. `undefined` expected
+ * print means "no expectation" → always matches.
+ */
+export function fontsMatch(fonts: PreviewFont[] | undefined, expectedFingerprint?: string): boolean {
+  if (expectedFingerprint == null) return true;
+  return fontFingerprint(fonts) === expectedFingerprint;
+}
+
+// ── portable hashing (no crypto dependency; runs in Node and the browser) ────
+
+function toBytes(data: Uint8Array | string): Uint8Array {
+  return typeof data === 'string' ? new TextEncoder().encode(data) : data;
+}
+
+/** FNV-1a in two 32-bit lanes → 16 hex chars. Enough to fingerprint font sets. */
+function hash(bytes: Uint8Array): string {
+  let h1 = 0x811c9dc5;
+  let h2 = 0xc9dc5118;
+  for (let i = 0; i < bytes.length; i++) {
+    const b = bytes[i];
+    h1 = Math.imul(h1 ^ b, 0x01000193);
+    h2 = Math.imul(h2 ^ b, 0x85ebca77);
+  }
+  return (h1 >>> 0).toString(16).padStart(8, '0') + (h2 >>> 0).toString(16).padStart(8, '0');
+}

--- a/packages/preview/tests/parity.test.ts
+++ b/packages/preview/tests/parity.test.ts
@@ -41,6 +41,44 @@ const HTML = `<!doctype html><html lang="en"><head><style>
   </table>
 </body></html>`;
 
+// A hermetic corpus of diverse shapes, inline so the gate needs no external
+// fixtures (a fresh CI checkout has everything). Rendering the WHOLE set — not
+// one doc — is what makes this a gate rather than an anecdote: any
+// preview-introduced divergence on any shape trips it. `page-counters` is the
+// important one: `counter(page)`/`counter(pages)` drive the 2–3 pass
+// sentinel-width path, the trickiest to keep byte-identical.
+const LONG_ROWS = Array.from({ length: 60 }, (_, i) => `<tr><td>Row ${i + 1}</td><td>€${i}.00</td></tr>`).join('');
+const CORPUS: Array<[string, string]> = [
+  ['invoice-table', HTML],
+  [
+    'multipage',
+    `<!doctype html><html lang="en"><head><style>
+       body { font-family: 'Liberation Sans', sans-serif; font-size: 11pt; margin: 20pt; }
+       table { width: 100%; border-collapse: collapse; }
+       td { border-bottom: 1px solid #ccc; padding: 3pt; }
+     </style></head><body><table><tbody>${LONG_ROWS}</tbody></table></body></html>`,
+  ],
+  [
+    'page-counters',
+    `<!doctype html><html lang="en"><head><style>
+       @page { margin: 40pt; @bottom-center { content: "Page " counter(page) " of " counter(pages); } }
+       body { font-family: 'Liberation Serif', serif; font-size: 11pt; }
+       p { margin: 0 0 8pt; }
+     </style></head><body>${Array.from({ length: 40 }, (_, i) => `<p>Paragraph ${i + 1}. The quick brown fox jumps over the lazy dog, repeatedly, to fill the page and force breaks.</p>`).join('')}</body></html>`,
+  ],
+  [
+    'borders-backgrounds',
+    `<!doctype html><html lang="en"><head><style>
+       body { font-family: 'Liberation Sans', sans-serif; margin: 24pt; }
+       .card { background: #eef2ff; border: 2px solid #6366f1; border-radius: 6px; padding: 12pt; margin-bottom: 10pt; }
+       .muted { color: #6b7280; }
+     </style></head><body>
+       <div class="card"><strong>Statement</strong><p class="muted">Balance carried forward.</p></div>
+       <div class="card">Line item — rendering seat.</div>
+     </body></html>`,
+  ],
+];
+
 beforeAll(async () => {
   await initBrowserProxy(readFileSync(WASM));
 });
@@ -58,6 +96,16 @@ describe('preview ↔ server parity', () => {
     expect(preview.pdf.length).toBe(server.pdf.length);
     expect(Buffer.from(preview.pdf).equals(Buffer.from(server.pdf))).toBe(true);
   });
+
+  // The gate: every corpus doc, preview bytes === server bytes.
+  for (const [name, html] of CORPUS) {
+    it(`corpus parity: ${name} — preview bytes === server bytes`, async () => {
+      const options = { fonts: standardFonts() };
+      const server = await renderServer(html, options);
+      const preview = await renderForPreview(html, options, renderBrowserProxy);
+      expect(Buffer.from(preview.pdf).equals(Buffer.from(server.pdf))).toBe(true);
+    });
+  }
 
   it('renderForPreview does not mutate or default the options object', async () => {
     const options = { fonts: standardFonts() };

--- a/packages/preview/tests/parity.test.ts
+++ b/packages/preview/tests/parity.test.ts
@@ -17,7 +17,7 @@ import { renderHtml as renderServer } from '@formepdf/html';
 import { init as initBrowserProxy, renderHtml as renderBrowserProxy } from '@formepdf/html/worker';
 
 // The unit under test — does not exist yet (this is the fails-first import).
-import { renderForPreview, fontFingerprint, standardFonts } from '../src/render.js';
+import { renderForPreview, fontFingerprint, fontsMatch, standardFonts } from '../src/render.js';
 
 const require = createRequire(import.meta.url);
 const WASM = require.resolve('@formepdf/html/pkg-web/forme_pdf_html_bg.wasm');
@@ -89,5 +89,20 @@ describe('font fingerprint — converts the silent case to a loud one', () => {
   it('treats undefined and empty font sets identically and stably', () => {
     expect(fontFingerprint(undefined)).toBe(fontFingerprint([]));
     expect(fontFingerprint([])).toBe(fontFingerprint([]));
+  });
+});
+
+describe('fontsMatch — the mismatch banner decision', () => {
+  it('fires (returns false) when the preview fonts differ from the server print', () => {
+    const server = standardFonts();
+    const serverPrint = fontFingerprint(server);
+    const previewMissingOne = server.slice(0, server.length - 1);
+    expect(fontsMatch(previewMissingOne, serverPrint)).toBe(false); // banner shows
+    expect(fontsMatch(server, serverPrint)).toBe(true); // banner hidden
+  });
+
+  it('no expected fingerprint means no expectation → always matches', () => {
+    expect(fontsMatch(undefined, undefined)).toBe(true);
+    expect(fontsMatch(standardFonts(), undefined)).toBe(true);
   });
 });

--- a/packages/preview/tests/parity.test.ts
+++ b/packages/preview/tests/parity.test.ts
@@ -1,0 +1,93 @@
+// FAILS-FIRST — the product's promise, written before the component exists.
+//
+// The whole point of @formepdf/preview is that what you see in the browser is
+// what the server produces. This test locks that: it renders the SAME
+// (html, options) through the server path (@formepdf/html Node entry) and
+// through the browser path (the /worker entry — the in-Node proxy for the
+// browser WASM, which embeds the byte-identical module, hash-asserted by the
+// html package's own targets-determinism gate), and requires byte-identical
+// PDFs. If anyone ever gives the preview a divergent options default or an
+// extra transform, this goes red — which is exactly when it should.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { renderHtml as renderServer } from '@formepdf/html';
+import { init as initBrowserProxy, renderHtml as renderBrowserProxy } from '@formepdf/html/worker';
+
+// The unit under test — does not exist yet (this is the fails-first import).
+import { renderForPreview, fontFingerprint, standardFonts } from '../src/render.js';
+
+const require = createRequire(import.meta.url);
+const WASM = require.resolve('@formepdf/html/pkg-web/forme_pdf_html_bg.wasm');
+
+// A small doc that references custom-registered families, so the font
+// embedding path is exercised (not just default base-14 metrics).
+const HTML = `<!doctype html><html lang="en"><head><style>
+  body { font-family: 'Liberation Sans', sans-serif; font-size: 12pt; margin: 24pt; }
+  h1 { font-family: 'Liberation Serif', serif; font-size: 20pt; }
+  table { width: 100%; border-collapse: collapse; margin-top: 12pt; }
+  td, th { border: 1px solid #333; padding: 4pt; text-align: left; }
+</style></head><body>
+  <h1>Invoice INV-001</h1>
+  <p>Prepared for Mandare. Amounts in EUR.</p>
+  <table>
+    <thead><tr><th>Item</th><th>Qty</th><th>Amount</th></tr></thead>
+    <tbody>
+      <tr><td>Rendering seat</td><td>3</td><td>€30.00</td></tr>
+      <tr><td>Support</td><td>1</td><td>€99.00</td></tr>
+    </tbody>
+  </table>
+</body></html>`;
+
+beforeAll(async () => {
+  await initBrowserProxy(readFileSync(WASM));
+});
+
+describe('preview ↔ server parity', () => {
+  it('renderForPreview (browser path) is byte-identical to server renderHtml', async () => {
+    // ONE options object — the same one a server handler would pass. Fonts are
+    // bytes (the only form the browser HTML path accepts), from the shared
+    // standardFonts() adapter, so both sides embed the identical glyph program.
+    const options = { fonts: standardFonts() };
+
+    const server = await renderServer(HTML, options);
+    const preview = await renderForPreview(HTML, options, renderBrowserProxy);
+
+    expect(preview.pdf.length).toBe(server.pdf.length);
+    expect(Buffer.from(preview.pdf).equals(Buffer.from(server.pdf))).toBe(true);
+  });
+
+  it('renderForPreview does not mutate or default the options object', async () => {
+    const options = { fonts: standardFonts() };
+    const before = JSON.stringify({ ...options, fonts: options.fonts.map((f) => f.family) });
+    await renderForPreview(HTML, options, renderBrowserProxy);
+    const after = JSON.stringify({ ...options, fonts: options.fonts.map((f) => f.family) });
+    expect(after).toBe(before); // no previewOptions: the object it renders is the object it was given
+  });
+});
+
+describe('font fingerprint — converts the silent case to a loud one', () => {
+  it('is order-independent and content-sensitive', () => {
+    const a = standardFonts();
+    const aReordered = [...a].reverse();
+    expect(fontFingerprint(a)).toBe(fontFingerprint(aReordered)); // same set, any order → same print
+
+    const bMissingOne = a.slice(0, a.length - 1); // server registered one more font than the preview
+    expect(fontFingerprint(a)).not.toBe(fontFingerprint(bMissingOne));
+  });
+
+  it('distinguishes different bytes under the same family/weight/style', () => {
+    const a = standardFonts();
+    const tampered = a.map((f, i) =>
+      i === 0 ? { ...f, data: new Uint8Array([...(f.data as Uint8Array), 0]) } : f,
+    );
+    expect(fontFingerprint(a)).not.toBe(fontFingerprint(tampered));
+  });
+
+  it('treats undefined and empty font sets identically and stably', () => {
+    expect(fontFingerprint(undefined)).toBe(fontFingerprint([]));
+    expect(fontFingerprint([])).toBe(fontFingerprint([]));
+  });
+});

--- a/packages/preview/tsconfig.json
+++ b/packages/preview/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## `@formepdf/preview` — byte-true in-browser PDF preview (v1, HTML path)

Renders HTML through the **same engine the server uses** and shows the **actual PDF** in an iframe, so preview and output agree by construction — not by approximation. This is the thing a Gotenberg/Puppeteer pipeline gets for free (the browser is both renderer and preview); now Forme gets it because the *engine* is both, and it paginates properly.

### Why it can't silently disagree with output
The audit found three ways a preview can diverge. All three are closed in code:
- **Display** — blob → iframe → the browser's native viewer shows the real bytes. No pdf.js-canvas rasterizer approximating the file.
- **Options** — there is no `previewOptions`. You pass the *same* `options` object to `<FormePreview>` and to your server's `renderHtml`. `renderForPreview` is a faithful passthrough; the guarantee is the *absence* of transforms.
- **Fonts** — the silent one. The browser HTML path can't fetch fonts, so the contract is bytes-only: `standardFonts()` adapts `@formepdf/fonts-standard` to `renderHtml`'s shape, and `fontFingerprint`/`fontsMatch` turn a font fall-back mismatch into a visible banner.

### What's here
- **`render.ts`** — the parity core (WASM-free, `renderHtml` injected): `renderForPreview`, `standardFonts`, `fontFingerprint`, `fontsMatch`.
- **`FormePreview.tsx`** — lazy ~7.7MB engine import (out of the initial bundle + a real loading gate), debounce, last-good-frame, loading/error, warnings surfaced, font-mismatch banner.
- **README** — the 7.7MB bundle cost is the first thing after the intro, not a footnote.

### The gate (the point of this PR)
A parity guarantee that's true today and unenforced quietly stops being true — and this one breaks *silently*. So there's a **`Test Preview (parity gate)`** CI step that asserts `renderForPreview` (browser-proxy `/worker` entry) is **byte-identical** to the Node `renderHtml` across a hermetic inline corpus, including the 2-pass `counter(page)`/`counter(pages)` path. Divergence fails the build.

Fails-first discipline: the byte-identity test was written and made **red** (before `render.ts` existed), then green. 11/11 pass; `tsc` clean.

### Scope
v1 is the HTML input path (matches the live prospect's pipeline exactly; simplest parity story). Deferred: JSX input, worker-render mode, a pdf.js-canvas mode (documented approximation), and a jsdom test for the React shell (the parity core — the load-bearing part — is covered; a broken iframe is visible immediately, a broken parity guarantee isn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
