### PR TITLE
CI: drop Google's Chrome apt source before every apt-get update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         # Google's Chrome apt source ships in the runner image and is briefly
         # inconsistent while Google rolls it ("Hash Sum mismatch", main,
         # 2026-09-09). Nothing here needs it; drop it before updating.
-        run: sudo rm -f /etc/apt/sources.list.d/google-chrome*.list && sudo apt-get update -q && sudo apt-get install -y -q poppler-utils
+        run: sudo grep -rl 'dl.google.com' /etc/apt/sources.list.d/ | xargs -r sudo rm -f && sudo apt-get update -q && sudo apt-get install -y -q poppler-utils
       - name: Run tests
         working-directory: engine
         # --features visual-tests: the visual-regression suite is part of
@@ -123,7 +123,7 @@ jobs:
           # "Hash Sum mismatch" on its Packages index failed main on
           # 2026-09-09), and Playwright's own Chromium never needed it.
           # Drop it before installing the system libraries.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
+          sudo grep -rl 'dl.google.com' /etc/apt/sources.list.d/ | xargs -r sudo rm -f
           npx playwright install --with-deps chromium
           node packages/html/test/browser-verify.mjs
       - name: Emit parity evidence (determinism)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
         # headline "runs in the browser" claim, verified not declared.
         run: |
           npm i --no-save playwright
+          # `--with-deps` runs apt-get update, which refreshes every source the
+          # runner image ships, including Google's Chrome repository. That
+          # repository is briefly inconsistent while Google rolls it (a
+          # "Hash Sum mismatch" on its Packages index failed main on
+          # 2026-09-09), and Playwright's own Chromium never needed it.
+          # Drop it before installing the system libraries.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*.list
           npx playwright install --with-deps chromium
           node packages/html/test/browser-verify.mjs
       - name: Emit parity evidence (determinism)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install poppler (pdftoppm for visual regression)
-        run: sudo apt-get update -q && sudo apt-get install -y -q poppler-utils
+        # Google's Chrome apt source ships in the runner image and is briefly
+        # inconsistent while Google rolls it ("Hash Sum mismatch", main,
+        # 2026-09-09). Nothing here needs it; drop it before updating.
+        run: sudo rm -f /etc/apt/sources.list.d/google-chrome*.list && sudo apt-get update -q && sudo apt-get install -y -q poppler-utils
       - name: Run tests
         working-directory: engine
         # --features visual-tests: the visual-regression suite is part of


### PR DESCRIPTION
The runner image ships Google's Chrome apt repository, and it is briefly inconsistent while Google rolls it. On today's main push (cfadb53) its Packages index failed a hash check ("Hash Sum mismatch") in two jobs: the Rust Engine job's `apt-get update` for poppler, and `playwright install --with-deps` in the HTML job. The conformance upload was skipped as a consequence.

No job in this workflow needs that repository: Playwright downloads its own Chromium, and poppler comes from Ubuntu. Each `apt-get update` now removes the source first.

Not a rerun: the failure recurs whenever Google's repository is mid-update, and this removes the dependency on it.