### PR TITLE
fix(preview): guard publish with a build step; bump 0.21.1

### DIFF
--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formepdf/preview",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "In-browser PDF preview for Forme — renders HTML through the same engine as the server and shows the actual PDF, so preview and output agree by construction.",
   "license": "MIT",
   "type": "module",
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@formepdf/fonts-standard": "^0.21.0",


### PR DESCRIPTION
## Why

`@formepdf/preview@0.21.0` published **empty** — the tarball is just `package.json` + `README.md`, no `dist/` (npm `fileCount = 2`). `dist` is gitignored, and a standalone `npm publish` ran without building, so `"files": ["dist"]` packed nothing. Anyone installing it gets `ERR_MODULE_NOT_FOUND` on import.

## Fix

- **`prepublishOnly: "npm run build"`** — the root cause was no build guard on a standalone publish (the coordinated `release.sh` builds everything; a manual `npm publish` had nothing enforcing it). Now `npm publish` always builds `dist` first.
- **Bump to `0.21.1`** — npm won't let `0.21.0` be overwritten.

## Verified

Clean `tsc` build against the **published** deps (consumer-equivalent, no workspace symlinks) emits `dist/`; the packed tarball is **8 files incl `dist/*.js` + `dist/*.d.ts`**. The code is unchanged from #89 (CI-green); this only adds the guard + version.

## After merge

Publish order matters (0.21.0 is currently the only version — unpublishing it first would remove the package name for 24h):
1. `npm publish` from main → ships `0.21.1` with `dist` (OTP)
2. then `npm unpublish @formepdf/preview@0.21.0` → drop the empty artifact (OTP)