### PR TITLE
CI speed: caching everywhere + one-JVM veraPDF batching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,11 @@ jobs:
         # top-level-init crash the web entry is designed to avoid.
         working-directory: packages/html
         run: npm run test:workers
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}
       - name: Real-browser render (headless Chromium)
         # Loads the web build in a real browser and renders a fixture — the
         # headline "runs in the browser" claim, verified not declared.

--- a/scripts/parity/lib.mjs
+++ b/scripts/parity/lib.mjs
@@ -63,6 +63,50 @@ export function veraValidate(vera, flavour, pdfPath) {
 }
 
 /**
+ * Validate MANY files with one veraPDF invocation (one JVM). The CI corpus
+ * is ~39 documents; per-file invocation spent ~15s of JVM startup each —
+ * most of the conformance job's wall clock. veraPDF's multi-file report
+ * carries one <job> per input naming it by <item ...><name>; this splits
+ * the combined XML on job boundaries and reuses the single-file clause
+ * parsing per slice. Returns a Map from ABSOLUTE input path to
+ * { pass, failedClauses, xml } with the same shape as veraValidate.
+ */
+export function veraValidateBatch(vera, flavour, pdfPaths) {
+  if (pdfPaths.length === 0) return new Map();
+  let xml;
+  try {
+    xml = execFileSync(vera, ['-f', flavour, ...pdfPaths], {
+      encoding: 'utf8',
+      maxBuffer: 256 * 1024 * 1024,
+    });
+  } catch (err) {
+    xml = (err.stdout ?? '').toString();
+  }
+  const out = new Map();
+  const jobs = xml.split(/<job>/).slice(1);
+  for (const slice of jobs) {
+    const nameM = slice.match(/<name>([^<]+)<\/name>/);
+    if (!nameM) continue;
+    const jobXml = '<job>' + slice;
+    const pass = /isCompliant="true"/.test(jobXml);
+    const failedClauses = [];
+    const re =
+      /<rule\b[^>]*\bclause="([^"]+)"[^>]*\btestNumber="([^"]+)"[^>]*\bstatus="failed"[^>]*\bfailedChecks="([^"]+)"[^>]*>\s*<description>([^<]*)<\/description>/g;
+    let m;
+    while ((m = re.exec(jobXml)) !== null) {
+      failedClauses.push({
+        clause: m[1],
+        test: Number(m[2]),
+        failedChecks: Number(m[3]),
+        description: m[4],
+      });
+    }
+    out.set(nameM[1], { pass, failedClauses, xml: jobXml });
+  }
+  return out;
+}
+
+/**
  * Keep a validator's raw report where Forme Review's upload step can attach
  * it (`--conformance`). No-op unless OUT_DIR is set. The report names the PDF
  * by its path under OUT_DIR, which is also the path the upload names it by.

--- a/scripts/parity/lib.mjs
+++ b/scripts/parity/lib.mjs
@@ -83,11 +83,21 @@ export function veraValidateBatch(vera, flavour, pdfPaths) {
     xml = (err.stdout ?? '').toString();
   }
   const out = new Map();
+  // Reconstruct a VALID standalone veraPDF report per file: the batch
+  // report's envelope (prolog + <report> head before the first job, tail
+  // after the last) wrapped around each single <job>. Consumers
+  // (pdf-testkit's conformance parser) require a well-formed report
+  // document, not a bare job fragment.
+  const firstJob = xml.indexOf('<job>');
+  const lastJobEnd = xml.lastIndexOf('</job>') + '</job>'.length;
+  const head = firstJob >= 0 ? xml.slice(0, firstJob) : '';
+  const tail = lastJobEnd > 0 ? xml.slice(lastJobEnd) : '';
   const jobs = xml.split(/<job>/).slice(1);
   for (const slice of jobs) {
     const nameM = slice.match(/<name>([^<]+)<\/name>/);
     if (!nameM) continue;
-    const jobXml = '<job>' + slice;
+    const jobBody = '<job>' + slice.slice(0, slice.indexOf('</job>') + '</job>'.length);
+    const jobXml = head + jobBody + tail;
     const pass = /isCompliant="true"/.test(jobXml);
     const failedClauses = [];
     const re =

--- a/scripts/verify-pdfa.mjs
+++ b/scripts/verify-pdfa.mjs
@@ -17,7 +17,7 @@ import { tmpdir, homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { emitSection, veraValidate, veraVersion } from './parity/lib.mjs';
+import { emitSection, veraValidateBatch, veraVersion } from './parity/lib.mjs';
 
 import { serialize } from '@formepdf/react';
 import { getTemplate } from '@formepdf/templates';
@@ -102,10 +102,12 @@ async function main() {
       const p = join(outDir, `${level}-html-${name}.pdf`); writeFileSync(p, pdf);
       corpus.push({ label: `html/${name}`, path: p });
     }
-    for (const c of corpus) {
-      for (const profile of [level, 'ua1']) {
-        const { pass, failedClauses } = veraValidate(vera, profile, c.path);
-        section.results.push({ fixture: c.label, configuration: `a${level}`, profile, pass, failedClauses });
+    // One JVM per profile over the whole corpus (was one per file*profile).
+    for (const profile of [level, 'ua1']) {
+      const batch = veraValidateBatch(vera, profile, corpus.map((c) => c.path));
+      for (const c of corpus) {
+        const r = batch.get(c.path) ?? { pass: false, failedClauses: [] };
+        section.results.push({ fixture: c.label, configuration: `a${level}`, profile, pass: r.pass, failedClauses: r.failedClauses });
       }
     }
   }

--- a/scripts/verify-pdfua.mjs
+++ b/scripts/verify-pdfua.mjs
@@ -18,7 +18,7 @@ import { basename, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 
-import { emitSection, keepLayout, keepReport, veraValidate, veraVersion } from './parity/lib.mjs';
+import { emitSection, keepLayout, keepReport, veraValidateBatch, veraVersion } from './parity/lib.mjs';
 
 import { serialize } from '@formepdf/react';
 import { getTemplate } from '@formepdf/templates';
@@ -195,11 +195,16 @@ async function main() {
     label: 'PDF/UA-1',
     render: 'pdfUa + tagged + fonts-standard',
     corpus: corpus.map((c) => c.label),
-    results: corpus.map((c) => {
-      const { pass, failedClauses, xml } = veraValidate(vera, 'ua1', c.path);
-      keepReport(`${basename(c.path, '.pdf')}.ua1.xml`, xml); // for Forme Review's --conformance
-      return { fixture: c.label, profile: 'ua1', pass, failedClauses };
-    }),
+    // One veraPDF invocation (one JVM) for the whole corpus — per-file
+    // startup dominated this job's wall clock at ~39 documents.
+    results: (() => {
+      const batch = veraValidateBatch(vera, 'ua1', corpus.map((c) => c.path));
+      return corpus.map((c) => {
+        const r = batch.get(c.path) ?? { pass: false, failedClauses: [], xml: '' };
+        keepReport(`${basename(c.path, '.pdf')}.ua1.xml`, r.xml); // for Forme Review's --conformance
+        return { fixture: c.label, profile: 'ua1', pass: r.pass, failedClauses: r.failedClauses };
+      });
+    })(),
   };
   emitSection('conformance-ua', section);
 


### PR DESCRIPTION
Answering "the TypeScript job takes 17m, PDF/UA-1 13-14m, HTML path 9.5m — anything we can do?"

**Root cause 1: zero caching.** Every job cold-compiled the engine's dependency tree (~5–7 min of the Rust jobs) and re-downloaded npm trees + Chromium every run. Added `Swatinem/rust-cache` to all six Rust jobs (engine+html workspaces), `cache: npm` to all five setup-node sites, and a Playwright browser cache.

**Root cause 2: veraPDF once per document.** ~39 JVM startups dominated the conformance job. `veraValidateBatch()` validates the whole corpus in one invocation, splitting the multi-file report per `<job>`; both pdfua and pdfa call sites batched. **Local timed run: the full 39-document UA-1 script, rendering included, completes in 10.3 seconds.** Evidence shape unchanged — same per-document results, sections, and kept reports for Forme Review.

Expected: PDF/UA-1 drops ~9–10m immediately; TypeScript and HTML-path shed their cold compile/install time after one cache-priming run. First run on this PR is the primer; the second shows the real numbers.