### PR TITLE
Lockfile: sync @formepdf/preview (main npm ci broken)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "forme-layout",
+  "name": "forme",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1662,6 +1662,10 @@
     },
     "node_modules/@formepdf/preact": {
       "resolved": "packages/preact",
+      "link": true
+    },
+    "node_modules/@formepdf/preview": {
+      "resolved": "packages/preview",
       "link": true
     },
     "node_modules/@formepdf/react": {
@@ -9096,6 +9100,24 @@
       },
       "peerDependencies": {
         "preact": "^10.19.0"
+      }
+    },
+    "packages/preview": {
+      "name": "@formepdf/preview",
+      "version": "0.21.1",
+      "license": "MIT",
+      "dependencies": {
+        "@formepdf/fonts-standard": "^0.21.0",
+        "@formepdf/html": "^0.21.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "packages/react": {


### PR DESCRIPTION
The preview package (#89) landed without a lockfile refresh. PR jobs use `npm install` and passed; main's benchmarks job runs `npm ci`, failed in 20s, and blocked the parity-page deploy. `npm ci --dry-run` verifies the sync.