### PR TITLE
Re-land the rust/npm caches (#94's rebase dropped them)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - name: Install poppler (pdftoppm for visual regression)
         # Google's Chrome apt source ships in the runner image and is briefly
         # inconsistent while Google rolls it ("Hash Sum mismatch", main,
@@ -55,9 +60,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Run tests
@@ -158,6 +169,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - name: Add llvm-tools to the pinned toolchain
         # rust-toolchain.toml pins the toolchain, and cargo-llvm-cov needs
         # the llvm-tools component on THAT toolchain — installing it on
@@ -217,7 +233,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
@@ -396,9 +418,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
@@ -455,6 +483,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - name: Download evidence partials
         uses: actions/download-artifact@v4
         with:
@@ -513,9 +542,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
The #94 rebase kept main's side of the ci.yml conflicts — only the Playwright cache survived; the six rust-cache and five npm-cache insertions never landed, which is why the cache store holds only Playwright entries and the warm run showed zero change. The caching experiment hasn't actually run yet. This PR's run primes; the following main run measures.