### PR TITLE
docs(preview): recommend build.target esnext over vite-plugin-top-level-await

### DIFF
--- a/packages/preview/README.md
+++ b/packages/preview/README.md
@@ -59,16 +59,24 @@ browser render path cannot fetch fonts — it takes bytes — so:
 ## Bundler setup
 
 The engine is self-instantiating WASM, so your bundler needs WASM + top-level
-await support. For Vite:
+await support. For Vite, add `vite-plugin-wasm` and target `esnext` (which emits
+native top-level await):
 
 ```ts
 // vite.config.ts
+import { defineConfig } from 'vite';
 import wasm from 'vite-plugin-wasm';
-import topLevelAwait from 'vite-plugin-top-level-await';
-export default { plugins: [wasm(), topLevelAwait()] };
+
+export default defineConfig({
+  plugins: [wasm()],
+  build: { target: 'esnext' },
+  optimizeDeps: { esbuildOptions: { target: 'esnext' } },
+});
 ```
 
-(Framework equivalents exist for webpack/Next/etc.)
+You can instead add `vite-plugin-top-level-await`, but it bundles `@swc/core`
+and can break on some SWC versions — the `esnext` target is the more robust
+route. (Framework equivalents exist for webpack/Next/etc.)
 
 ## Props
 


### PR DESCRIPTION
`vite-plugin-top-level-await` bundles `@swc/core` and throws `missing field type` on current SWC versions — hit while building a real demo app against the published `@formepdf/preview@0.21.1`. Targeting `esnext` emits native top-level await with one fewer plugin, so the README's Vite snippet now recommends that and notes the TLA plugin as a fragile fallback.

Docs-only. (The npm README will pick this up on the next publish.)