### PR TITLE
CI: build the WASM once, share it as an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,42 @@ jobs:
       - name: PDF size regression check
         run: bash .github/scripts/check-pdf-size.sh
 
+  wasm:
+    name: WASM artifacts (build once, share everywhere)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build core WASM (three targets)
+        working-directory: packages/core
+        run: npm run build:wasm
+      - name: Build html WASM (three targets)
+        working-directory: packages/html
+        run: ./build.sh
+      - name: Upload WASM packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkgs
+          retention-days: 1
+          path: |
+            packages/core/pkg
+            packages/core/pkg-node
+            packages/core/pkg-web
+            packages/html/pkg
+            packages/html/pkg-node
+            packages/html/pkg-web
+
   html-parity:
     name: HTML Input Path (tests + native/WASM parity)
     runs-on: ubuntu-latest
-    needs: engine
+    needs: [engine, wasm]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -69,8 +101,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Run tests
         working-directory: html
         run: cargo test
@@ -83,9 +113,11 @@ jobs:
       - name: Build native CLI
         working-directory: html
         run: cargo build --release --bin forme-html
-      - name: Build WASM package
-        working-directory: packages/html
-        run: ./build.sh
+      - name: Download WASM packages (built once in the wasm job)
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkgs
+          path: packages
       - name: Native vs WASM byte-equality
         # Determinism across compilation targets is load-bearing for two
         # launch claims (same engine everywhere; reproducible output).
@@ -227,7 +259,7 @@ jobs:
   packages:
     name: TypeScript Packages
     runs-on: ubuntu-latest
-    needs: engine
+    needs: [engine, wasm]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -240,8 +272,6 @@ jobs:
           workspaces: |
             engine
             html
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
         run: npm install
       - name: Build Shared package
@@ -256,12 +286,17 @@ jobs:
         # vite can't resolve @formepdf/fonts-standard on a fresh checkout.
         working-directory: packages/fonts-standard
         run: npm run build
-      - name: Build Core (WASM + TS)
+      - name: Download WASM packages (built once in the wasm job)
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkgs
+          path: packages
+      - name: Build Core (TS over the downloaded WASM)
         # Must build before Svelte's check step: svelte-check typechecks
         # render-document.ts and preview/index.ts, both of which import
         # types from @formepdf/core.
         working-directory: packages/core
-        run: npm run build
+        run: npm run build:ts
       - name: Assert Core tarball layout
         # Belt-and-braces against the 0.10.0 publish miss: pack the
         # package and verify every entry-point file is present. Catches
@@ -270,14 +305,7 @@ jobs:
         # script that forgets to emit a required entry.
         working-directory: packages/core
         run: bash ./scripts/assert-tarball.sh
-      - name: Build HTML WASM package
-        # @formepdf/renderer's HTML input path (and its sfc tests) import
-        # @formepdf/html, whose ESM entry statically imports ./pkg-node/…;
-        # vite resolves that eagerly at transform time, so the WASM must exist
-        # before Build/Test Renderer on a fresh checkout. (This job only needs
-        # the Node target, but build.sh emits all three, matching core.)
-        working-directory: packages/html
-        run: ./build.sh
+      # HTML WASM comes from the shared artifact downloaded above.
       - name: Build Renderer
         working-directory: packages/renderer
         run: npm run build
@@ -407,7 +435,7 @@ jobs:
   benchmarks:
     name: Benchmarks (ci evidence column)
     runs-on: ubuntu-latest
-    needs: engine
+    needs: [engine, wasm]
     # Push to main, or manual dispatch on any branch (to observe a real runner
     # before merging). Minutes of runtime, PRs don't need it. NEVER a gate: the
     # emitter records gaps/timeouts as data and the step is continue-on-error, so
@@ -427,18 +455,15 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
         run: npm ci
       - name: Build native CLI
         run: cd html && cargo build --release --bin forme-html
-      - name: Build HTML WASM (node + web targets)
-        run: |
-          cd html
-          wasm-pack build --target nodejs --out-dir ../packages/html/pkg-node -- --features wasm
-          wasm-pack build --target web    --out-dir ../packages/html/pkg-web  -- --features wasm
-          rm -f ../packages/html/pkg-node/.gitignore ../packages/html/pkg-web/.gitignore
+      - name: Download WASM packages (built once in the wasm job)
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkgs
+          path: packages
       - name: Install browser runtime for the baseline
         # Full puppeteer (bundled Chromium). The emitter prefers puppeteer,
         # falling back to puppeteer-core + system Chrome locally. miniflare is
@@ -538,7 +563,7 @@ jobs:
   pdfua-conformance:
     name: PDF/UA-1 Conformance (veraPDF)
     runs-on: ubuntu-latest
-    needs: engine
+    needs: [engine, wasm]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -555,8 +580,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
         run: npm install
       # The gate renders through two front doors, so both engine builds and
@@ -570,15 +593,17 @@ jobs:
       - name: Build fonts-standard
         working-directory: packages/fonts-standard
         run: npm run build
-      - name: Build Core (WASM + TS)
+      - name: Download WASM packages (built once in the wasm job)
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkgs
+          path: packages
+      - name: Build Core (TS over the downloaded WASM)
         working-directory: packages/core
-        run: npm run build
+        run: npm run build:ts
       - name: Build Templates
         working-directory: packages/templates
         run: npm run build
-      - name: Build HTML WASM package
-        working-directory: packages/html
-        run: ./build.sh
       - name: Install veraPDF
         # Install under $HOME (guaranteed writable; /opt is root-owned on the
         # runner) and export the binary path for the next step.


### PR DESCRIPTION
The predicted real lever: six wasm-pack release compilations of the same engine per run (html-parity ×1, TypeScript ×2, benchmarks ×2, conformance ×2-ish). A dedicated `wasm` job — parallel with the engine job, rust-cached — builds all six target dirs once and uploads a 1-day artifact; the four consumers download it, core's build drops to `build:ts`, and wasm-pack installs once instead of five times.

This PR's own run is the proof: its job times ARE the shared-wasm times (the artifact mechanism doesn't need cache warmth). Comparison against the baseline lands in the thread.