### PR TITLE
PDF 2.0 output: pdfVersion option + ISO 32000-2 writer arms

### DIFF
--- a/docs/images/templates/manifest.json
+++ b/docs/images/templates/manifest.json
@@ -1,122 +1,122 @@
 {
   "invoice-standard": {
-    "hash": "7d55b5907b4857121213e4311d8261081fda3c2891b72e63797ba03a76a01bce",
+    "hash": "3ea2ae95e791f99177a1841e7312326eb714c19fe4a780782296957484aef027",
     "pages": 1
   },
   "invoice-detailed": {
-    "hash": "2606c0b8e40b5218cf8a87c706380bedcc5192132fa3bb40756df951c08a36ed",
+    "hash": "ef66f5642c2df298da3b0b15d7868a0739ff92f7beb495d68bef8eda1ed9c372",
     "pages": 3
   },
   "credit-note": {
-    "hash": "b29f712ff60d8e2a015e6caed36e51f085eb09ef05af9db4577b14ddba30eac0",
+    "hash": "e7730fd96271fdc4c8d71d800cdf8b7eab97c5fb251c5ceb3c7508dfce79c086",
     "pages": 1
   },
   "receipt": {
-    "hash": "5420da96a8dacbe7510e12f2a64ffbd7814d896d38312879dd29955bf430db0b",
+    "hash": "f0e423f2773433a9c6581873e66f6639db56e8b0b7a5944d23e9e619b0e8f7b3",
     "pages": 1
   },
   "quote": {
-    "hash": "4f952ba77d84de961aa71e11ae50145b14f94bd260ce19e58d5d27acb1a19c10",
+    "hash": "1c681eb70dd2ec71ef8cc6ce6c2b07caec5f0511f2d5638382fbf497a4dc086f",
     "pages": 1
   },
   "statement": {
-    "hash": "99e34fdc6cd1d34037f8dad19c815ec37c583742c7e3b271908dbfe0bb69cdd7",
+    "hash": "d00258abe7e5c31b1e800e422c582fb3c43aebb138a2c2f14f65df42493f0392",
     "pages": 1
   },
   "purchase-order": {
-    "hash": "03be5bacfc25c76a33d91b7cd1006409257baefc5cb22d45e55496fce6efadfc",
+    "hash": "d4156ec8503d88eff3739eb5f669de3902b512363641ee22caee4d4796cca116",
     "pages": 1
   },
   "remittance-advice": {
-    "hash": "95a9c98f002a12bb29f3e93e747e4fa6279461c71edc4c1b5f2823200a26eba6",
+    "hash": "f2c9fd6d65eb9df08936a0055bbc26e36d255a5f4c58669ec24aa78e0ee251b3",
     "pages": 1
   },
   "expense-report": {
-    "hash": "29aa8fc1b525f41d5997fa49aa779e4977871a30d17cdd5f444c07b142ae0265",
+    "hash": "abcb3c5ad354afb7782165d96616c6aa3b692f91fee740dc16a6e5825f2071ac",
     "pages": 1
   },
   "payslip": {
-    "hash": "4d09671013df5bade73d04671f27242b2e91ffd5c1deb8aecf8bb6fda47ad576",
+    "hash": "242486895e0bb4052086ce3caf714d3bad73e4549f649b4d325833fb6d12f207",
     "pages": 1
   },
   "letterhead": {
-    "hash": "203537c3fcceffd0048f5602ec01ffb0297572a5dc292a1af84503d1c8664002",
+    "hash": "6e7196f265df917ce163dd4c560b9fa8dbf64be1aba4f08ebdaf4c3e5986c57b",
     "pages": 2
   },
   "cover-letter": {
-    "hash": "b03a10e57be9c2e677de865c3f92f5d48d3bc949caf071936d44e2800bd216c1",
+    "hash": "72f856da356a5b8059180c266e61f1dcda5b9bb60303b140d0993c8d92e0ab37",
     "pages": 1
   },
   "memo": {
-    "hash": "2f81f2850436322ed1f3e4ddc7bec3eb314f67479db22b93785f37ea399eaf42",
+    "hash": "abd0d7edbafa4bd4f605b4d97938d63542483c8f59c5e85dba9b797f2ef9484d",
     "pages": 1
   },
   "employment-contract": {
-    "hash": "c5dccb0f1d04a70af5bc060fdf3af6d3cc5ccb9eee73a2a94523ada860150fa8",
+    "hash": "06e039d82a963b795787f7d26ec2078587e3a12045873c05e2fcafac01c426e3",
     "pages": 3
   },
   "nda": {
-    "hash": "d3573f5b0c35c50e2b52bbd8b84a83341ac0d90113b34bd7d4e264ac5315ad7a",
+    "hash": "d314575a97541f80a90d0ec7a0278f88b2cca0cbb826edd8e7078fc682c484e4",
     "pages": 2
   },
   "service-agreement": {
-    "hash": "1c5a715aeb85b61142c8ee04ca30b12ca2fb9f6b7fcbabf244c4b6cd9e56cc1d",
+    "hash": "84e1362b4603378fc56378cae1fdbada4f1d7cbe8c6df9d3c6ac23bd8ebec27d",
     "pages": 3
   },
   "offer-letter": {
-    "hash": "e8ab656d5c6ea1a6803b5690d468237c6759fdc33e6454f350305c360bbab62d",
+    "hash": "cfc3924fcaffac705e03ccb3c84bf2b6bcb34ef8d5d9d0051754d97e5def9ea3",
     "pages": 1
   },
   "termination-letter": {
-    "hash": "e8224573daeda71a83abdbbc36d5200c51acc1576c7403460412b2bb38837d88",
+    "hash": "470d9db4981e945d4662265c7eb9c46fac3cb4914fc97fba1d617cc3ed870241",
     "pages": 1
   },
   "reference-letter": {
-    "hash": "5ed27d3758188ffd0774b3f160d8739807feae9d880657182bd36a086d4aebda",
+    "hash": "d8d95af4ca0bd6c286cc133dc98c905adcc4a7993ff863c3e1ac512a8f79f5b6",
     "pages": 1
   },
   "policy-acknowledgement": {
-    "hash": "981f9399e61728e5c283852e408e9d198afaea48c51c1f173ad3ce89d319db62",
+    "hash": "2700a07c161bc5d5c2e86cafeebe0a7c12f9207d81cac575068388bfdee65b5c",
     "pages": 1
   },
   "report-annual": {
-    "hash": "19f9e6123bf4fcfbb7e4640aa79cfcd3e17d3324e7512b2425ad3fb281287ca2",
+    "hash": "7f6cc4f3ccda2d787d5c8f7491d99e7856bda666e227960c385825754e0dc403",
     "pages": 3
   },
   "report-monthly": {
-    "hash": "bb5b3f64522f0a2cf9045dc457b8e4ec6668ff5898c829a9207d2a86d9d1222d",
+    "hash": "6ad3033dca8d78d2f81ef14fb7dc1210b73b229c5953d846218b778c2d4fcba6",
     "pages": 1
   },
   "lab-report": {
-    "hash": "6b84188f86a1b5879809a8714c2d6b701ce7f164927f10936755102a0f39948a",
+    "hash": "dbd2216e060f5d5b647e42107f07a3c229532d66c51f93a1cd57d2a98dc9990d",
     "pages": 1
   },
   "inspection-report": {
-    "hash": "9a01706bb5c3a24f717a082e58c100d767445c6f7032edb98a535481a958acdd",
+    "hash": "6104105aeb661df859a5dc0a376ba6cec3ae298ec8d9332d40653d667c5faf29",
     "pages": 1
   },
   "shipping-label": {
-    "hash": "c2436df92829c61aca9a6cf17c0be0ecefd95361ba94efb162a96b972fb8ee18",
+    "hash": "8f08296937142254ea10b765cd465f4d0a112066dfef027897e2ac22a1ed0e97",
     "pages": 1
   },
   "packing-slip": {
-    "hash": "c033074bec2bae359c3087faaff806c6cd23ec747d6ffc3d7270dd25d9c178c8",
+    "hash": "f3221467fa1be97df1ad4fc87425124738fc05d223f5cfc4d2720cb1e9d14035",
     "pages": 1
   },
   "delivery-note": {
-    "hash": "05fce858f5d7c288f796b45e1b9359238940ed844585d33cda22cedf2b41f6ad",
+    "hash": "8b22f51aa9f9fda0f90772d7404c0d17c12d4b63dc38749d7995969bbed79463",
     "pages": 1
   },
   "certificate": {
-    "hash": "c99c14329e375c3532e2105d3b2e00f715555bfbedd014c0908af443330e8d8c",
+    "hash": "5be102274de06e041f6ca6a02751af05905bf31d6729e09cf3fa875c6b4a2e58",
     "pages": 1
   },
   "product-catalog": {
-    "hash": "efb5861ea294b0c6876d5db1fdffeedbcf72f0e3eae99ed3db5c5ca85a6c04cc",
+    "hash": "c54f3fb033ba94ed7b45737a68b94b897bb8a5a6193c45bb45ffebf342eb8ad6",
     "pages": 2
   },
   "meeting-minutes": {
-    "hash": "5f30e118663ec6ad007fc10f42a14262648c3b3481a08fb42501de77ae5cc3b7",
+    "hash": "744309a4b9e6d8a378b0d8be8c177bd76a1f1fccc8eb70d79a8bc2407db0d5c6",
     "pages": 1
   }
 }

--- a/engine/src/layout/audit.rs
+++ b/engine/src/layout/audit.rs
@@ -452,6 +452,7 @@ mod tests {
             zugferd: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         }
     }
 

--- a/engine/src/layout/mod.rs
+++ b/engine/src/layout/mod.rs
@@ -7990,6 +7990,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8054,6 +8055,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8119,6 +8121,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8197,6 +8200,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8288,6 +8292,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
         let pages = engine.layout(&doc, &font_context);
         let page = &pages[0];
@@ -8438,6 +8443,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8513,6 +8519,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8600,6 +8607,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8665,6 +8673,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8741,6 +8750,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8828,6 +8838,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8914,6 +8925,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -8994,6 +9006,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);
@@ -9066,6 +9079,7 @@ mod tests {
             flatten_forms: false,
             pdf_ua: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pages = engine.layout(&doc, &font_context);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -232,10 +232,37 @@ pub fn render_with_warnings_and_passes(
 }
 
 /// Like [`render_with_warnings_and_passes`], with opt-in [`RenderOptions`].
+/// PDF 2.0 contradicts every ISO 32000-1 (PDF 1.7) based conformance
+/// claim: PDF/A-2 and A-3 are defined over 1.7, as is PDF/UA-1. Error by
+/// name rather than emit a file whose header falsifies its own claim.
+fn validate_pdf_version(document: &Document) -> Result<(), FormeError> {
+    use crate::model::{PdfAConformance, PdfVersion};
+    if document.pdf_version != PdfVersion::V2_0 {
+        return Ok(());
+    }
+    if let Some(level) = &document.pdfa {
+        let family = match level {
+            PdfAConformance::A2a | PdfAConformance::A2b | PdfAConformance::A2u => "PDF/A-2",
+            PdfAConformance::A3a | PdfAConformance::A3b | PdfAConformance::A3u => "PDF/A-3",
+        };
+        return Err(FormeError::RenderError(format!(
+            "pdfVersion \"2.0\" contradicts pdfa: {family} is defined over ISO 32000-1              (PDF 1.7). Drop the pdfa claim, or keep pdfVersion \"1.7\" (the default).              PDF/A-4 is the 2.0-based archival standard."
+        )));
+    }
+    if document.pdf_ua {
+        return Err(FormeError::RenderError(
+            "pdfVersion \"2.0\" contradicts pdfUa: PDF/UA-1 is defined over ISO 32000-1              (PDF 1.7). Drop the pdfUa claim, or keep pdfVersion \"1.7\" (the default).              PDF/UA-2 is the 2.0-based accessibility standard."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn render_with_options(
     document: &Document,
     options: RenderOptions,
 ) -> Result<(Vec<u8>, Vec<String>, u32), FormeError> {
+    validate_pdf_version(document)?;
     // Coarse phase profiling behind FORME_PROFILE (native only in practice —
     // `env::var` is Err under wasm, so the timer is never constructed there and
     // `Instant::now` is never called). Prints layout vs serialize to stderr.
@@ -272,6 +299,7 @@ pub fn render_with_options(
         &document.attachments,
         document.zugferd.as_ref(),
         document.flatten_forms,
+        document.pdf_version,
     )?;
     let warnings = {
         let mut all = layout_warnings;
@@ -322,6 +350,7 @@ pub fn render_with_layout_and_options(
     document: &Document,
     options: RenderOptions,
 ) -> Result<(Vec<u8>, LayoutInfo, Vec<String>, u32), FormeError> {
+    validate_pdf_version(document)?;
     let (pages, font_context, passes, layout_warnings) =
         layout_with_sentinel_passes_audited(document, options.audit_content);
     let layout_info = LayoutInfo::from_pages(&pages);
@@ -343,6 +372,7 @@ pub fn render_with_layout_and_options(
         &document.attachments,
         document.zugferd.as_ref(),
         document.flatten_forms,
+        document.pdf_version,
     )?;
     let pdf = if let Some(ref sig_config) = document.certification {
         pdf::certify::certify_pdf(&pdf, sig_config)?

--- a/engine/src/model/mod.rs
+++ b/engine/src/model/mod.rs
@@ -82,6 +82,17 @@ pub struct Document {
     #[serde(default)]
     pub pdfa: Option<PdfAConformance>,
 
+    /// Output PDF version. `1.7` (the default) is today's writer,
+    /// byte-for-byte. `2.0` writes an ISO 32000-2 file: the %PDF-2.0
+    /// header, XMP document metadata always (no trailer /Info — 2.0
+    /// deprecates its entries and PDF/A-4 forbids the key), and embedded
+    /// fonts required (2.0 removes the standard-14 provision, so a
+    /// non-embedded Helvetica is a bet on reader goodwill; register
+    /// fonts or use fonts-standard, exactly as pdfA requires). 1.7-based
+    /// conformance claims (pdfA 2*/3*, pdfUa) are hard errors under 2.0.
+    #[serde(default)]
+    pub pdf_version: PdfVersion,
+
     /// When true, the PDF claims PDF/UA-1 conformance. Forces `tagged = true`.
     #[serde(default)]
     pub pdf_ua: bool,
@@ -117,6 +128,18 @@ pub struct Document {
     /// with the specified X.509 certificate and RSA private key.
     #[serde(default, skip_serializing_if = "Option::is_none", alias = "signature")]
     pub certification: Option<CertificationConfig>,
+}
+
+/// The output PDF version. The 1.7 arm is the writer as it has always
+/// been; every 2.0 behavior lives behind explicit `V2_0` match arms so
+/// the default path is textually unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum PdfVersion {
+    #[default]
+    #[serde(rename = "1.7")]
+    V1_7,
+    #[serde(rename = "2.0")]
+    V2_0,
 }
 
 /// PDF/A conformance level.

--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -150,6 +150,9 @@ struct PdfBuilder {
     /// write: a silently wrong glyph is a render defect (decision 2026-09-08 —
     /// keep the bundled font, make the register-a-font path discoverable).
     missing_glyphs: std::cell::RefCell<std::collections::BTreeSet<char>>,
+    /// Output version — read by serialize() for the header; every other
+    /// 2.0 behavior is decided in write() before objects are built.
+    pdf_version: crate::model::PdfVersion,
 }
 
 pub(crate) struct PdfObject {
@@ -203,6 +206,7 @@ impl PdfWriter {
         attachments: &[Attachment],
         zugferd: Option<&ZugferdMeta>,
         flatten_forms: bool,
+        pdf_version: crate::model::PdfVersion,
     ) -> Result<(Vec<u8>, Vec<String>), FormeError> {
         // ── Attachment / e-invoice validation (before any emission) ──
         //
@@ -281,6 +285,7 @@ impl PdfWriter {
             shading_map: HashMap::new(),
             warnings: Vec::new(),
             missing_glyphs: Default::default(),
+            pdf_version: Default::default(),
         };
 
         // Reserve object IDs:
@@ -302,7 +307,8 @@ impl PdfWriter {
         });
 
         // Register the fonts actually used across all pages
-        self.register_fonts(&mut builder, pages, font_context, pdf_ua)?;
+        builder.pdf_version = pdf_version;
+        self.register_fonts(&mut builder, pages, font_context, pdf_ua, pdf_version)?;
 
         // PDF/A: validate that all fonts are embedded. A font counts as
         // embedded if the caller registered custom bytes for it OR it's a
@@ -539,27 +545,31 @@ impl PdfWriter {
             None
         };
 
-        // PDF/A and/or PDF/UA: write XMP metadata stream and ICC output intent
-        let xmp_metadata_id = if pdfa.is_some() || pdf_ua {
-            let xmp_xml = xmp::generate_xmp(metadata, pdfa, pdf_ua, zugferd);
-            let xmp_bytes = xmp_xml.as_bytes();
-            let xmp_obj_id = builder.objects.len();
-            // XMP metadata stream must NOT be compressed (PDF/A requirement)
-            let xmp_data = format!(
-                "<< /Type /Metadata /Subtype /XML /Length {} >>\nstream\n",
-                xmp_bytes.len()
-            );
-            let mut xmp_obj_data: Vec<u8> = xmp_data.into_bytes();
-            xmp_obj_data.extend_from_slice(xmp_bytes);
-            xmp_obj_data.extend_from_slice(b"\nendstream");
-            builder.objects.push(PdfObject {
-                id: xmp_obj_id,
-                data: xmp_obj_data,
-            });
-            Some(xmp_obj_id)
-        } else {
-            None
-        };
+        // PDF/A and/or PDF/UA — and ALWAYS under PDF 2.0, where document
+        // metadata lives in XMP (the trailer /Info entries are deprecated
+        // in ISO 32000-2 and the key itself is forbidden by veraPDF's
+        // PDF/A-4 profile): write the XMP metadata stream.
+        let xmp_metadata_id =
+            if pdfa.is_some() || pdf_ua || pdf_version == crate::model::PdfVersion::V2_0 {
+                let xmp_xml = xmp::generate_xmp(metadata, pdfa, pdf_ua, zugferd);
+                let xmp_bytes = xmp_xml.as_bytes();
+                let xmp_obj_id = builder.objects.len();
+                // XMP metadata stream must NOT be compressed (PDF/A requirement)
+                let xmp_data = format!(
+                    "<< /Type /Metadata /Subtype /XML /Length {} >>\nstream\n",
+                    xmp_bytes.len()
+                );
+                let mut xmp_obj_data: Vec<u8> = xmp_data.into_bytes();
+                xmp_obj_data.extend_from_slice(xmp_bytes);
+                xmp_obj_data.extend_from_slice(b"\nendstream");
+                builder.objects.push(PdfObject {
+                    id: xmp_obj_id,
+                    data: xmp_obj_data,
+                });
+                Some(xmp_obj_id)
+            } else {
+                None
+            };
 
         let output_intent_id = if pdfa.is_some() {
             // Embed sRGB ICC profile
@@ -1306,7 +1316,15 @@ impl PdfWriter {
         .into_bytes();
 
         // Info dictionary (metadata)
-        let info_obj_id = if metadata.title.is_some() || metadata.author.is_some() {
+        // No trailer /Info under PDF 2.0: its entries are deprecated in
+        // ISO 32000-2 and veraPDF's PDF/A-4 profile forbids the key
+        // ("The Info key shall not be present in the trailer dictionary …
+        // unless there exists a PieceInfo entry", which we never emit).
+        // Document metadata lives in the XMP stream, emitted above
+        // unconditionally for 2.0.
+        let info_obj_id = if pdf_version == crate::model::PdfVersion::V1_7
+            && (metadata.title.is_some() || metadata.author.is_some())
+        {
             let id = builder.objects.len();
             let mut info = String::from("<< ");
             if let Some(ref title) = metadata.title {
@@ -2824,6 +2842,7 @@ impl PdfWriter {
         pages: &[LayoutPage],
         font_context: &FontContext,
         pdf_ua: bool,
+        pdf_version: crate::model::PdfVersion,
     ) -> Result<(), FormeError> {
         // Collect font usage: glyph IDs, chars, and glyph→char mapping per font
         let mut font_usage_map: HashMap<FontKey, FontUsage> = HashMap::new();
@@ -2867,7 +2886,7 @@ impl PdfWriter {
                     // WinAnsiEncoding — the content stream is untouched (same
                     // `(text) Tj` WinAnsi path, same positions), only the font
                     // dictionary gains an embedded program.
-                    if pdf_ua {
+                    if pdf_ua || pdf_version == crate::model::PdfVersion::V2_0 {
                         if Self::emit_pdfua_embedded_standard(
                             builder,
                             key,
@@ -2876,6 +2895,25 @@ impl PdfWriter {
                             font_context,
                         ) {
                             continue;
+                        }
+                        // PDF 2.0 removes the standard-14 provision —
+                        // conforming readers need not ship these fonts, so
+                        // non-embedded base-14 output is a bet on reader
+                        // goodwill. Hard error by name, with the remedy,
+                        // exactly like the pdfA contract.
+                        if pdf_version == crate::model::PdfVersion::V2_0 {
+                            let remedy = match std_font.liberation_family() {
+                                Some(lib) => format!(
+                                    "install @formepdf/fonts-standard and register its fonts (`for (const f of standardFonts()) Font.register(f)`) — Forme will embed the metric-compatible {lib} in its place"
+                                ),
+                                None => "register an embeddable TrueType font for this text                                          (Symbol/ZapfDingbats have no metric-compatible substitute)"
+                                    .to_string(),
+                            };
+                            return Err(FormeError::FontError(format!(
+                                "pdfVersion \"2.0\": font '{}' is not embedded. ISO 32000-2 removes the standard-14 provision, so every font must be embedded — {}.",
+                                std_font.pdf_name(),
+                                remedy,
+                            )));
                         }
                         // Substitution didn't happen. If a metric-compatible
                         // substitute exists but wasn't registered, say so by
@@ -4241,7 +4279,10 @@ impl PdfWriter {
         let mut offsets: Vec<usize> = vec![0; builder.objects.len()];
 
         // Header
-        output.extend_from_slice(b"%PDF-1.7\n");
+        output.extend_from_slice(match builder.pdf_version {
+            crate::model::PdfVersion::V1_7 => b"%PDF-1.7\n".as_slice(),
+            crate::model::PdfVersion::V2_0 => b"%PDF-2.0\n".as_slice(),
+        });
         output.extend_from_slice(b"%\xe2\xe3\xcf\xd3\n");
 
         for (i, obj) in builder.objects.iter().enumerate().skip(1) {
@@ -4653,6 +4694,7 @@ mod tests {
                 &[],
                 None,
                 false,
+                crate::model::PdfVersion::V1_7,
             )
             .unwrap();
 
@@ -4695,6 +4737,7 @@ mod tests {
                 &[],
                 None,
                 false,
+                crate::model::PdfVersion::V1_7,
             )
             .unwrap();
         let text = String::from_utf8_lossy(&bytes);
@@ -4824,6 +4867,7 @@ mod tests {
                 &[],
                 None,
                 false,
+                crate::model::PdfVersion::V1_7,
             )
             .unwrap();
         let text = String::from_utf8_lossy(&bytes);
@@ -4995,6 +5039,7 @@ mod tests {
                 &[],
                 None,
                 false,
+                crate::model::PdfVersion::V1_7,
             )
             .unwrap();
         let text = String::from_utf8_lossy(&bytes);

--- a/engine/src/pdf/redaction.rs
+++ b/engine/src/pdf/redaction.rs
@@ -2502,6 +2502,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -2558,6 +2559,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -2603,6 +2605,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -2684,6 +2687,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -2847,6 +2851,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -2898,6 +2903,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3025,6 +3031,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3073,6 +3080,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3116,6 +3124,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3162,6 +3171,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3208,6 +3218,7 @@ mod tests {
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");
@@ -3337,6 +3348,7 @@ endcmap
             embedded_data: None,
             flatten_forms: false,
             certification: None,
+            pdf_version: Default::default(),
         };
 
         let pdf_bytes = crate::render(&doc).expect("render should succeed");

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -125,6 +125,7 @@ fn default_doc(children: Vec<Node>) -> Document {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     }
 }
 
@@ -595,6 +596,7 @@ fn test_metadata_in_output() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -741,6 +743,7 @@ fn render_with_custom_font(font_data: &[u8], text: &str) -> Vec<u8> {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let engine = LayoutEngine::new();
@@ -758,6 +761,7 @@ fn render_with_custom_font(font_data: &[u8], text: &str) -> Vec<u8> {
             &doc.attachments,
             doc.zugferd.as_ref(),
             doc.flatten_forms,
+            forme::model::PdfVersion::V1_7,
         )
         .unwrap()
         .0
@@ -903,6 +907,7 @@ fn test_mixed_standard_and_custom_fonts() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let engine = LayoutEngine::new();
@@ -920,6 +925,7 @@ fn test_mixed_standard_and_custom_fonts() {
             &[],
             None,
             false,
+            forme::model::PdfVersion::V1_7,
         )
         .unwrap();
 
@@ -3304,6 +3310,7 @@ fn test_breakable_view_with_background_splits_across_pages() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pages = layout_doc(&doc);
@@ -3393,6 +3400,7 @@ fn test_breakable_view_background_does_not_overlap_footer() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pages = layout_doc(&doc);
@@ -3470,6 +3478,7 @@ fn test_breakable_view_without_visual_stays_unwrapped() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pages = layout_doc(&doc);
@@ -3807,6 +3816,7 @@ fn test_breakable_view_continuation_page_has_top_padding() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pages = layout_doc(&doc);
@@ -4165,6 +4175,7 @@ fn test_document_lang_in_pdf_catalog() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -4413,6 +4424,7 @@ fn test_justified_text_produces_valid_pdf() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).expect("Should render justified text");
@@ -4477,6 +4489,7 @@ fn test_lang_inherits_to_text_nodes() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     // Just verify it renders without error — lang cascading is tested at the unit level
@@ -4556,6 +4569,7 @@ fn test_per_node_lang_override() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).expect("Should render with per-node lang override");
@@ -4588,6 +4602,7 @@ fn test_tagged_pdf_has_struct_tree_root() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).unwrap();
@@ -4656,6 +4671,7 @@ fn test_tagged_pdf_parent_tree_consistency() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).unwrap();
@@ -4736,6 +4752,7 @@ fn test_tagged_pdf_nested_text_roles() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).unwrap();
@@ -4838,6 +4855,7 @@ fn test_tagged_pdf_table_th_td() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).unwrap();
@@ -4897,6 +4915,7 @@ fn test_tagged_pdf_figure_alt_text() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let bytes = forme::render(&doc).unwrap();
@@ -5171,6 +5190,7 @@ fn test_qrcode_renders_to_pdf() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).expect("QR code should render to PDF");
@@ -5210,6 +5230,7 @@ fn test_qrcode_with_explicit_size() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -5261,6 +5282,7 @@ fn test_qrcode_page_break() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -5324,6 +5346,7 @@ fn test_font_fallback_chain_in_document() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).expect("Fallback chain should render");
@@ -5409,6 +5432,7 @@ fn test_text_overflow_ellipsis_single_line() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -5788,6 +5812,7 @@ fn test_document_default_style() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let pdf = render_to_pdf(&doc);
     let pdf_str = String::from_utf8_lossy(&pdf);
@@ -5824,6 +5849,7 @@ fn test_embedded_data_round_trip() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let pdf = render_to_pdf(&doc);
     assert_valid_pdf(&pdf);
@@ -5917,6 +5943,7 @@ fn test_barcode_renders_to_pdf() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).expect("Barcode should render to PDF");
@@ -5990,6 +6017,7 @@ fn test_barcode_layout_dimensions() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -6048,6 +6076,7 @@ fn auto_margin_horizontal_centers_child() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -6110,6 +6139,7 @@ fn auto_margin_left_pushes_right() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -6436,6 +6466,7 @@ fn test_bar_chart_layout_dimensions() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -7190,6 +7221,7 @@ fn test_pdf_ua_has_viewer_preferences() {
         flatten_forms: false,
         pdf_ua: true,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7227,6 +7259,7 @@ fn test_pdf_ua_has_xmp_pdfuaid() {
         flatten_forms: false,
         pdf_ua: true,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7257,6 +7290,7 @@ fn test_pdf_ua_forces_tagging() {
         flatten_forms: false,
         pdf_ua: true,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7298,6 +7332,7 @@ fn test_pdf_ua_and_pdfa_combined_xmp() {
         flatten_forms: false,
         pdf_ua: true,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7341,6 +7376,7 @@ fn test_tagged_pdf_has_tab_order() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7371,6 +7407,7 @@ fn test_untagged_pdf_no_tab_order() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7401,6 +7438,7 @@ fn test_tagged_role_map_omits_standard_self_mappings() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7450,6 +7488,7 @@ fn test_tagged_struct_tree_has_lang() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = render_to_pdf(&doc);
     assert_valid_pdf(&bytes);
@@ -7850,6 +7889,7 @@ fn test_certify_at_render_time() {
             width: None,
             height: None,
         }),
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -8293,6 +8333,7 @@ fn test_page_placeholder_survives_line_breaking() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (pdf, _layout, _) = forme::render_with_layout(&doc).unwrap();
@@ -8383,6 +8424,7 @@ fn test_two_pass_multi_page_common_case() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let (pdf, layout, _) = forme::render_with_layout(&doc).unwrap();
     assert!(layout.pages.len() >= 2, "Should be multi-page");
@@ -8440,6 +8482,7 @@ fn test_render_performance() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let start = Instant::now();
@@ -8530,6 +8573,7 @@ fn test_multi_weight_font_resolution() {
         pdfa: None,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -8581,6 +8625,7 @@ fn test_svg_opacity_produces_ext_gstate() {
         pdfa: None,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -8634,6 +8679,7 @@ fn test_svg_fill_opacity_produces_ext_gstate() {
         pdfa: None,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -8681,6 +8727,7 @@ fn test_svg_inherited_group_opacity() {
         pdfa: None,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -9004,6 +9051,7 @@ fn test_page_background_opacity_creates_extgstate() {
         pdf_ua: false,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let pdf_bytes = render_to_pdf(&doc);
     let pdf_str = String::from_utf8_lossy(&pdf_bytes);
@@ -10596,6 +10644,7 @@ fn test_heading_emits_h1_through_h6_structure_roles_in_tagged_pdf() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = forme::render(&doc).unwrap();
     let pdf_str = String::from_utf8_lossy(&bytes);
@@ -10638,6 +10687,7 @@ fn test_heading_renders_text_content() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = forme::render(&doc).unwrap();
     let stream = decompress_pdf_streams(&bytes);
@@ -10833,6 +10883,7 @@ fn test_list_emits_l_li_lbl_in_tagged_pdf() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let bytes = forme::render(&doc).unwrap();
     let pdf_str = String::from_utf8_lossy(&bytes);
@@ -11253,6 +11304,7 @@ fn siblings_after_overflowing_flex_row_still_render() {
         embedded_data: None,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
@@ -11522,6 +11574,7 @@ fn first_page_config_gives_page_one_its_own_margins() {
         embedded_data: None,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
     assert!(layout.pages.len() >= 2, "content must flow to page 2");
@@ -11552,6 +11605,7 @@ fn not_first_header_skips_page_one() {
         embedded_data: None,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
     assert!(layout.pages.len() >= 2);
@@ -11653,6 +11707,7 @@ fn first_page_restores_margin_when_its_band_is_suppressed() {
         embedded_data: None,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     let (_pdf, layout, _) = forme::render_with_layout(&doc).expect("Should render");
     assert!(layout.pages.len() >= 2);
@@ -12632,4 +12687,93 @@ fn covered_text_reports_no_missing_glyph_defect() {
         !warnings.iter().any(|w| w.contains("rendered as \"?\"")),
         "covered text must not warn: {warnings:?}"
     );
+}
+
+// ── PDF 2.0 output (ISO 32000-2) ────────────────────────────────────────
+
+fn doc20(extra: &str) -> String {
+    // Builtin Noto Sans is a CUSTOM (embedded) font on every platform —
+    // the 2.0 path requires embeddable fonts, so the fixture uses it.
+    format!(
+        r#"{{ "children": [ {{ "kind": {{ "type": "Text", "content": "hello 2.0" }}, "style": {{ "fontFamily": "Noto Sans" }}, "children": [] }} ],
+            "metadata": {{ "title": "Two Point Oh" }}, "pdfVersion": "2.0"{extra} }}"#
+    )
+}
+
+fn doc20_base14(extra: &str) -> String {
+    format!(
+        r#"{{ "children": [ {{ "kind": {{ "type": "Text", "content": "hello 2.0" }}, "style": {{}}, "children": [] }} ],
+            "metadata": {{}}, "pdfVersion": "2.0"{extra} }}"#
+    )
+}
+
+#[test]
+fn pdf20_header_and_no_trailer_info() {
+    // A 2.0 file: %PDF-2.0 header; document metadata lives in XMP, and
+    // the trailer carries NO /Info — 2.0 deprecates its entries and
+    // veraPDF's PDF/A-4 profile forbids the key outright ("The Info key
+    // shall not be present in the trailer dictionary … unless there
+    // exists a PieceInfo entry", which we never emit). Plain 2.0 and
+    // A-4 behave identically here by design.
+    let bytes = forme::render_json(&doc20("")).expect("2.0 doc renders");
+    assert!(bytes.starts_with(b"%PDF-2.0"), "header must declare 2.0");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(!text.contains("/Info "), "no trailer /Info in 2.0 output");
+    assert!(
+        text.contains("/Metadata"),
+        "2.0 output must always carry an XMP metadata stream"
+    );
+    assert!(
+        text.contains("Two Point Oh"),
+        "the title must reach the XMP packet"
+    );
+}
+
+#[test]
+fn pdf20_requires_embeddable_fonts() {
+    // 2.0 removes the standard-14 provision: conforming readers need not
+    // ship Helvetica, so non-embedded base-14 output is a bet on reader
+    // goodwill. Same contract as pdfA: error by name, register a font
+    // (or fonts-standard) to proceed.
+    let e = forme::render_json(&doc20_base14("")).unwrap_err();
+    let msg = e.to_string();
+    assert!(
+        msg.contains("Helvetica") && msg.contains("fonts-standard") && msg.contains("2.0"),
+        "must name the font and the remedy: {msg}"
+    );
+}
+
+#[test]
+fn pdf20_rejects_17_based_conformance_claims() {
+    // PDF/A-2 and A-3 are ISO 32000-1 (1.7) standards; PDF/UA-1 likewise.
+    // Claiming them in a 2.0 file is a contradiction and errors by name,
+    // like the missing-font case.
+    let e = forme::render_json(&doc20(r#", "pdfa": "2b""#)).unwrap_err();
+    assert!(
+        e.to_string().contains("PDF/A-2") && e.to_string().contains("2.0"),
+        "A-2 under 2.0 must error by name: {e}"
+    );
+    let e = forme::render_json(&doc20(r#", "pdfa": "3b""#)).unwrap_err();
+    assert!(
+        e.to_string().contains("PDF/A-3") && e.to_string().contains("2.0"),
+        "A-3 under 2.0 must error by name: {e}"
+    );
+    let e = forme::render_json(&doc20(r#", "pdfUa": true"#)).unwrap_err();
+    assert!(
+        e.to_string().contains("PDF/UA-1") && e.to_string().contains("2.0"),
+        "UA-1 under 2.0 must error by name: {e}"
+    );
+}
+
+#[test]
+fn pdf17_output_is_byte_identical_with_the_version_field_present() {
+    // The structural guarantee, asserted: an explicit pdfVersion "1.7"
+    // and an absent field produce the same bytes — the default path
+    // never consults the new option.
+    let plain = r#"{ "children": [ { "kind": { "type": "Text", "content": "hello" }, "style": {}, "children": [] } ], "metadata": {} }"#;
+    let explicit = r#"{ "children": [ { "kind": { "type": "Text", "content": "hello" }, "style": {}, "children": [] } ], "metadata": {}, "pdfVersion": "1.7" }"#;
+    let a = forme::render_json(plain).unwrap();
+    let b = forme::render_json(explicit).unwrap();
+    assert_eq!(a, b, "explicit 1.7 must be byte-identical to the default");
+    assert!(a.starts_with(b"%PDF-1.7"));
 }

--- a/engine/tests/visual_regression.rs
+++ b/engine/tests/visual_regression.rs
@@ -265,6 +265,7 @@ fn visual_invoice() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -308,6 +309,7 @@ fn visual_multi_page_text() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -447,6 +449,7 @@ fn visual_table_header_repetition() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -507,6 +510,7 @@ fn visual_flex_layout() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -567,6 +571,7 @@ fn visual_justified_text() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -651,6 +656,7 @@ fn visual_line_breaking_greedy_vs_optimal() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();
@@ -731,6 +737,7 @@ fn visual_text_alignment() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
         attachments: vec![],
         first_page: None,
         left_page: None,
@@ -773,6 +780,7 @@ fn visual_tagged_no_visual_change() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let doc_tagged = Document {
@@ -797,6 +805,7 @@ fn visual_tagged_no_visual_change() {
         flatten_forms: false,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf_untagged = forme::render(&doc_untagged).unwrap();
@@ -957,6 +966,7 @@ fn visual_flattened_forms() {
         flatten_forms: true,
         pdf_ua: false,
         certification: None,
+        pdf_version: Default::default(),
     };
 
     let pdf = forme::render(&doc).unwrap();

--- a/html/src/map.rs
+++ b/html/src/map.rs
@@ -154,6 +154,7 @@ pub fn map_html(
         embedded_data: None,
         flatten_forms: false,
         certification: None,
+        pdf_version: Default::default(),
     };
     (doc, mapper.warnings)
 }


### PR DESCRIPTION
Campaign PR 1 of 2 (PDF 2.0 + PDF/A-4, per the approved Phase 0). Engine core only; TS/HTML plumbing, docs (with the loud font-embedding note), and the conformance-gate extension land with A-4 in PR 2.

`pdfVersion: "1.7" | "2.0"`, default 1.7. **The 1.7 path is textually today's writer** — every 2.0 behavior is an explicit `V2_0` arm:
- `%PDF-2.0` header; XMP document metadata always; **no trailer `/Info`** — the rule verified against veraPDF's shipped PDFA-4.xml ("The Info key shall not be present … unless there exists a PieceInfo entry"), not a spec summary, per the review hold.
- **Embedded fonts required** (32000-2 removes the standard-14 provision): reuses the pdfUa Liberation substitution, hard-errors by name with the remedy — the pdfA contract applied to the version.
- 1.7-based claims are contradictions by name: `pdfa 2*/3*` and `pdfUa` each error, pointing at their 2.0-based successors.

**Pins:** header/XMP/no-Info; the font error naming font + remedy; all three contradiction errors; and the structural guarantee *asserted* — explicit `"1.7"` byte-identical to the absent field. Byte-wall 6/6 IDENTICAL; engine 577 + html 235 green, clippy clean.

**Dry-run evidence for PR 2's scope:** a plain 2.0 file through veraPDF's full A-4 profile fails exactly two clauses — 6.7.3 (pdfaid identification, absent by definition) and 6.2.4.3 (OutputIntent, already emitted under pdfa) — parse, fonts, Info, and structure all clean. A-4 is those two clauses plus variant plumbing.