### PR TITLE
PDF/A-4 and A-4f: identification, gates, surfaces

### DIFF
--- a/docs/archival.mdx
+++ b/docs/archival.mdx
@@ -62,6 +62,33 @@ const pdf = await renderDocument(<Document pdfa="3b">...</Document>, {
 
 Attachments under PDF/A-**2** are refused with a named error — part 2 permits only PDF/A attachments, which the engine cannot verify; the error tells you to use `"3b"`. The main use case, Factur-X/ZUGFeRD e-invoice containers, has [its own guide](/einvoicing).
 
+### PDF/A-4 (`4`, `4f`) — the PDF 2.0 archival standard
+
+ISO 19005-4:2020 is defined over **PDF 2.0** (ISO 32000-2). Claiming it implies `pdfVersion: "2.0"` — the header, XMP-only document metadata (no trailer Info dictionary), and one consequence worth reading twice:
+
+<Warning>
+**Every font must be embedded under PDF 2.0.** ISO 32000-2 removes the special provision for the standard-14 fonts, so Forme's non-embedded Helvetica/Times/Courier defaults hard-error under `pdfa="4"` (and under plain `pdfVersion: "2.0"`). Register [@formepdf/fonts-standard](https://www.npmjs.com/package/@formepdf/fonts-standard) or your own fonts — the same requirement the 1.7 PDF/A levels already carry, now triggered by the version itself.
+</Warning>
+
+<Warning>
+**PDF/A-4 is not an accessibility claim.** Part 4 drops the a/b/u split entirely — there is no Level A, and no tagging requirement. Accessibility moved wholly to **PDF/UA-2**, which Forme does not yet produce. If "archival AND accessible" is the goal today, that combination is `pdfa="2a"` (or `"3a"`) + `pdfUa` on PDF 1.7. "PDF/A-4 verified" says the file will open identically in thirty years; it says nothing about screen readers.
+</Warning>
+
+```tsx
+// Plain A-4 — no attachments permitted beyond other PDF/A files
+const pdf = await renderDocument(<Document pdfa="4">...</Document>);
+
+// A-4f — arbitrary embedded files, and AT LEAST ONE IS REQUIRED:
+// an A-4f file with an empty EmbeddedFiles tree is itself
+// non-conformant (ISO 19005-4 Annex A; veraPDF clause 6.9-t5), so
+// Forme refuses a "4f" claim with nothing attached.
+const pdf4f = await renderDocument(<Document pdfa="4f">...</Document>, {
+  attachments: [{ name: 'data.csv', data: csvBytes, mimeType: 'text/csv' }],
+});
+```
+
+Both levels are veraPDF-validated in CI over the same corpus as the 1.7 levels. The 1.7-based claims (`pdfa` 2x/3x, `pdfUa`) are contradictions under `pdfVersion: "2.0"` and error by name. The HTML path accepts `pdf_a: "4"`; `"4f"` there is refused until the HTML path grows an attachments option.
+
 ---
 
 ## What Forme Handles

--- a/docs/images/templates/manifest.json
+++ b/docs/images/templates/manifest.json
@@ -1,122 +1,122 @@
 {
   "invoice-standard": {
-    "hash": "3ea2ae95e791f99177a1841e7312326eb714c19fe4a780782296957484aef027",
+    "hash": "9ce0c34c6bb595ca7766a1eff7e43735ae2fb859eab8f4015f7bcd84c320364c",
     "pages": 1
   },
   "invoice-detailed": {
-    "hash": "ef66f5642c2df298da3b0b15d7868a0739ff92f7beb495d68bef8eda1ed9c372",
+    "hash": "ff799dce925fe893ea32be4d1e34a082f0a4244cc46f1878cfba3471433c1f79",
     "pages": 3
   },
   "credit-note": {
-    "hash": "e7730fd96271fdc4c8d71d800cdf8b7eab97c5fb251c5ceb3c7508dfce79c086",
+    "hash": "07856559dc31de5d7bad75d4166d2596837c869c64d042ba486e6e55d2f87bb1",
     "pages": 1
   },
   "receipt": {
-    "hash": "f0e423f2773433a9c6581873e66f6639db56e8b0b7a5944d23e9e619b0e8f7b3",
+    "hash": "5e57553731b626e4f7e2028fc3fbc638aa85f95a4aaaa63649c88a865fc2fda1",
     "pages": 1
   },
   "quote": {
-    "hash": "1c681eb70dd2ec71ef8cc6ce6c2b07caec5f0511f2d5638382fbf497a4dc086f",
+    "hash": "7e07eb1d911ade21747264875ddf0eb6d9b538964685c04576708c4d24c20a30",
     "pages": 1
   },
   "statement": {
-    "hash": "d00258abe7e5c31b1e800e422c582fb3c43aebb138a2c2f14f65df42493f0392",
+    "hash": "29224b85fa54fffec8e51ba0a8d5cdc11bba4b3f020ac8f75f0614fca9c66300",
     "pages": 1
   },
   "purchase-order": {
-    "hash": "d4156ec8503d88eff3739eb5f669de3902b512363641ee22caee4d4796cca116",
+    "hash": "eef5266aed0ee271727a52a52a96f04aeb636bed22b97e2e6f25a8ea37a81944",
     "pages": 1
   },
   "remittance-advice": {
-    "hash": "f2c9fd6d65eb9df08936a0055bbc26e36d255a5f4c58669ec24aa78e0ee251b3",
+    "hash": "cb37d4b4f81a31673f53b8bee5f47d7ea8decc516a82cea8bf80adf34a87157b",
     "pages": 1
   },
   "expense-report": {
-    "hash": "abcb3c5ad354afb7782165d96616c6aa3b692f91fee740dc16a6e5825f2071ac",
+    "hash": "593228b2632bbd383683ecdcaf463c55960049b54063e3117f9b203596af9676",
     "pages": 1
   },
   "payslip": {
-    "hash": "242486895e0bb4052086ce3caf714d3bad73e4549f649b4d325833fb6d12f207",
+    "hash": "a80834004f91b1c2b10387218847dfe5c6805ac2e57c3c2fcc7c9fd422cfde3d",
     "pages": 1
   },
   "letterhead": {
-    "hash": "6e7196f265df917ce163dd4c560b9fa8dbf64be1aba4f08ebdaf4c3e5986c57b",
+    "hash": "5b8299be0461a8190e8c60ed3a66921ebca16928190845b3903d44ec4d528417",
     "pages": 2
   },
   "cover-letter": {
-    "hash": "72f856da356a5b8059180c266e61f1dcda5b9bb60303b140d0993c8d92e0ab37",
+    "hash": "cb735751e4a5a8453036ed547af9a2227e5b9da23fa5e937a169f1c22901b9a0",
     "pages": 1
   },
   "memo": {
-    "hash": "abd0d7edbafa4bd4f605b4d97938d63542483c8f59c5e85dba9b797f2ef9484d",
+    "hash": "5c842cf759fd64aead009c4eb7d817b05372b01e3b3796dcb15122ce55f27a09",
     "pages": 1
   },
   "employment-contract": {
-    "hash": "06e039d82a963b795787f7d26ec2078587e3a12045873c05e2fcafac01c426e3",
+    "hash": "e0145257794a01a49d39aea0a54a75839a2e5546f61b5fa41b0903bc5ab959fc",
     "pages": 3
   },
   "nda": {
-    "hash": "d314575a97541f80a90d0ec7a0278f88b2cca0cbb826edd8e7078fc682c484e4",
+    "hash": "5f52ebf06d73d762bdd14afa87ddef3cf4e8777ab782f4f662d227352617f004",
     "pages": 2
   },
   "service-agreement": {
-    "hash": "84e1362b4603378fc56378cae1fdbada4f1d7cbe8c6df9d3c6ac23bd8ebec27d",
+    "hash": "991adb16441038cae9d9d79200566cc10be22273f3205ad6d97d6331a5c6fca4",
     "pages": 3
   },
   "offer-letter": {
-    "hash": "cfc3924fcaffac705e03ccb3c84bf2b6bcb34ef8d5d9d0051754d97e5def9ea3",
+    "hash": "78a160a89e31c58f6646a5be259a3dd348b37387f2feeea466eb0f447641f877",
     "pages": 1
   },
   "termination-letter": {
-    "hash": "470d9db4981e945d4662265c7eb9c46fac3cb4914fc97fba1d617cc3ed870241",
+    "hash": "840ec7de1d6571d3f1352f9bb0fd78201fc5570b478ec31d5004b1fa2570272b",
     "pages": 1
   },
   "reference-letter": {
-    "hash": "d8d95af4ca0bd6c286cc133dc98c905adcc4a7993ff863c3e1ac512a8f79f5b6",
+    "hash": "0a3be209588c386ea26f51efe175d051050a190f6efcab7d475e2c9fac3b1b7f",
     "pages": 1
   },
   "policy-acknowledgement": {
-    "hash": "2700a07c161bc5d5c2e86cafeebe0a7c12f9207d81cac575068388bfdee65b5c",
+    "hash": "5c8b3ef09e351d323fb5af9b9770227935c0c8a8c7f4ece0ae3a9688c7027bce",
     "pages": 1
   },
   "report-annual": {
-    "hash": "7f6cc4f3ccda2d787d5c8f7491d99e7856bda666e227960c385825754e0dc403",
+    "hash": "88d1c963cb6f042e22cb131a87585568b4e6e330b31d13685323015e195d84b4",
     "pages": 3
   },
   "report-monthly": {
-    "hash": "6ad3033dca8d78d2f81ef14fb7dc1210b73b229c5953d846218b778c2d4fcba6",
+    "hash": "18107a2294df4f139f7a80ea0a61e41b373b3cb537712889ba25bf7988108b35",
     "pages": 1
   },
   "lab-report": {
-    "hash": "dbd2216e060f5d5b647e42107f07a3c229532d66c51f93a1cd57d2a98dc9990d",
+    "hash": "33288cdebdab299f13399464f3bbc7f073da81271b22ff41448f12a49dc0a8af",
     "pages": 1
   },
   "inspection-report": {
-    "hash": "6104105aeb661df859a5dc0a376ba6cec3ae298ec8d9332d40653d667c5faf29",
+    "hash": "d5fbb3e2d5b5a5ca7cdc3986f02651099ed5220fd1fc163f324da36f6f50d5f3",
     "pages": 1
   },
   "shipping-label": {
-    "hash": "8f08296937142254ea10b765cd465f4d0a112066dfef027897e2ac22a1ed0e97",
+    "hash": "ae0b0ec9f1e429f85cb549951e5679c11967683c8d791ee8d7205a3e3bdbe6c0",
     "pages": 1
   },
   "packing-slip": {
-    "hash": "f3221467fa1be97df1ad4fc87425124738fc05d223f5cfc4d2720cb1e9d14035",
+    "hash": "0887a6072a04d998bffae768d3f825e9099bc421a3caa6d8ae019fd6c8a58e22",
     "pages": 1
   },
   "delivery-note": {
-    "hash": "8b22f51aa9f9fda0f90772d7404c0d17c12d4b63dc38749d7995969bbed79463",
+    "hash": "b14faa5c3f90a6d1311b30f655ce8144e2782134026194165c962ec071197081",
     "pages": 1
   },
   "certificate": {
-    "hash": "5be102274de06e041f6ca6a02751af05905bf31d6729e09cf3fa875c6b4a2e58",
+    "hash": "ffd3e3edb3ae0e7c3ee599d8a2c0f6b39d94ee7328a0e91343d981cb15575a8a",
     "pages": 1
   },
   "product-catalog": {
-    "hash": "c54f3fb033ba94ed7b45737a68b94b897bb8a5a6193c45bb45ffebf342eb8ad6",
+    "hash": "257f9889ce8ee418b16d7278dee659cbf64719e51a05b07e46db9237f10b30ae",
     "pages": 2
   },
   "meeting-minutes": {
-    "hash": "744309a4b9e6d8a378b0d8be8c177bd76a1f1fccc8eb70d79a8bc2407db0d5c6",
+    "hash": "84a79800276d91bf4549b5c33d7eb936c98b893c6b505e843dfbcc3c5af27840",
     "pages": 1
   }
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PDF 2.0 output** (`pdfVersion: "2.0"`, default `"1.7"` — byte-identical for non-requesting documents, asserted by pin): `%PDF-2.0` header, XMP document metadata always, no trailer `/Info` (deprecated in ISO 32000-2; forbidden by veraPDF's PDF/A-4 profile), and **embedded fonts required** — 32000-2 removes the standard-14 provision, so base-14 output hard-errors by name with the fonts-standard remedy. 1.7-based conformance claims (`pdfa` 2x/3x, `pdfUa`) are contradictions and error by name.
+- **PDF/A-4 and PDF/A-4f** (ISO 19005-4:2020): `pdfa: "4" | "4f"`, implying PDF 2.0. Identification per veraPDF's shipped rule set — `pdfaid:part` 4, `pdfaid:rev` 2020, conformance only for `4f` ("F"). Base A-4 refuses attachments (only PDF/A files are permitted, which the engine cannot verify); **A-4f requires at least one embedded file** (clause 6.9-t5 — an empty EmbeddedFiles tree is itself non-conformant) and refuses an attachment-less claim. Both levels veraPDF-validated in CI over the standing corpus. NOTE: A-4 carries **no accessibility requirement** — the a/b/u split is gone; accessibility is PDF/UA-2 territory.
+
 ### Changed (behavior — all text ink moves; line boxes and page breaks do not)
 
 - **Baselines use real font metrics.** The glyph block inside a line box is now `(ascent + descent) * font_size` (hhea metrics for custom fonts, the metric-compatible faces' values for the base-14 families), with half-leading splitting the remainder and the baseline sitting `ascent` below the block top — the CSS line box model as browsers implement it. The previous model used `font_size` as a stand-in for the whole block, which sat every baseline `fs*(1 - ascent + descent)/2` lower than a browser (~0.15em for Arial-class metrics) and made single glyphs centered by the line-height idiom ride visibly low. Line boxes, element geometry, page breaks, and page counts are unchanged — only ink position within each line moves, by exactly the per-font predicted delta; baseline-alignment shoves (flex `align-items: baseline`, table-cell `vertical-align: baseline`) are recomputed under the same model and now match glyph placement exactly.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -235,6 +235,18 @@ pub fn render_with_warnings_and_passes(
 /// PDF 2.0 contradicts every ISO 32000-1 (PDF 1.7) based conformance
 /// claim: PDF/A-2 and A-3 are defined over 1.7, as is PDF/UA-1. Error by
 /// name rather than emit a file whose header falsifies its own claim.
+/// PDF/A-4 is defined over ISO 32000-2: claiming it IMPLIES PDF 2.0
+/// output, whatever pdfVersion says (the serde default cannot be told
+/// apart from an explicit "1.7", so the claim wins — the alternative is
+/// a file whose header falsifies its own conformance).
+fn effective_pdf_version(document: &Document) -> crate::model::PdfVersion {
+    use crate::model::{PdfAConformance, PdfVersion};
+    match &document.pdfa {
+        Some(PdfAConformance::A4 | PdfAConformance::A4f) => PdfVersion::V2_0,
+        _ => document.pdf_version,
+    }
+}
+
 fn validate_pdf_version(document: &Document) -> Result<(), FormeError> {
     use crate::model::{PdfAConformance, PdfVersion};
     if document.pdf_version != PdfVersion::V2_0 {
@@ -244,6 +256,9 @@ fn validate_pdf_version(document: &Document) -> Result<(), FormeError> {
         let family = match level {
             PdfAConformance::A2a | PdfAConformance::A2b | PdfAConformance::A2u => "PDF/A-2",
             PdfAConformance::A3a | PdfAConformance::A3b | PdfAConformance::A3u => "PDF/A-3",
+            // A-4 is the 2.0-based standard: no contradiction — it
+            // IMPLIES pdfVersion 2.0 (applied at render time below).
+            PdfAConformance::A4 | PdfAConformance::A4f => return Ok(()),
         };
         return Err(FormeError::RenderError(format!(
             "pdfVersion \"2.0\" contradicts pdfa: {family} is defined over ISO 32000-1              (PDF 1.7). Drop the pdfa claim, or keep pdfVersion \"1.7\" (the default).              PDF/A-4 is the 2.0-based archival standard."
@@ -299,7 +314,7 @@ pub fn render_with_options(
         &document.attachments,
         document.zugferd.as_ref(),
         document.flatten_forms,
-        document.pdf_version,
+        effective_pdf_version(document),
     )?;
     let warnings = {
         let mut all = layout_warnings;
@@ -372,7 +387,7 @@ pub fn render_with_layout_and_options(
         &document.attachments,
         document.zugferd.as_ref(),
         document.flatten_forms,
-        document.pdf_version,
+        effective_pdf_version(document),
     )?;
     let pdf = if let Some(ref sig_config) = document.certification {
         pdf::certify::certify_pdf(&pdf, sig_config)?

--- a/engine/src/model/mod.rs
+++ b/engine/src/model/mod.rs
@@ -163,6 +163,16 @@ pub enum PdfAConformance {
     /// PDF/A-3u: like 2u, plus arbitrary embedded files.
     #[serde(rename = "3u")]
     A3u,
+    /// PDF/A-4 (ISO 19005-4:2020): the PDF 2.0 archival standard. No
+    /// a/b/u conformance split — and NO accessibility requirement:
+    /// tagging levels moved wholly to PDF/UA-2. Implies pdfVersion 2.0.
+    /// Attachments are restricted to other PDF/A files (unverifiable
+    /// here, so refused — the A-2 rationale).
+    #[serde(rename = "4")]
+    A4,
+    /// PDF/A-4f: A-4 plus arbitrary embedded files (pdfaid:conformance F).
+    #[serde(rename = "4f")]
+    A4f,
 }
 
 impl PdfAConformance {
@@ -170,7 +180,7 @@ impl PdfAConformance {
     /// other PDF/A files (veraPDF rule 6.8-5), which the engine cannot
     /// verify — so attachments under a 2x level are refused.
     pub fn allows_attachments(&self) -> bool {
-        matches!(self, Self::A3a | Self::A3b | Self::A3u)
+        matches!(self, Self::A3a | Self::A3b | Self::A3u | Self::A4f)
     }
 }
 

--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -217,11 +217,33 @@ impl PdfWriter {
         // embedded files.
         if let Some(level) = pdfa {
             if !level.allows_attachments() && (embedded_data.is_some() || !attachments.is_empty()) {
+                use crate::model::PdfAConformance as L;
+                let (family, clause, remedy) = match level {
+                    L::A4 => ("PDF/A-4", "ISO 19005-4", "pdfa: \"4f\""),
+                    _ => (
+                        "PDF/A-2",
+                        "ISO 19005-2, 6.8",
+                        "a PDF/A-3 level — e.g. pdfa: \"3b\"",
+                    ),
+                };
+                return Err(FormeError::RenderError(format!(
+                    "{family} forbids embedded files that are not themselves PDF/A \
+                     ({clause}), which the engine cannot verify. Use {remedy}, which \
+                     permits arbitrary attachments, or remove the attachment / embedData."
+                )));
+            }
+            // The inverse rule, from veraPDF's PDFA-4F profile verbatim
+            // (6.9-t5): "A PDF/A-4f conforming file shall contain an
+            // EmbeddedFiles key" — an A-4f claim with NOTHING embedded is
+            // itself non-conformant.
+            if matches!(level, crate::model::PdfAConformance::A4f)
+                && embedded_data.is_none()
+                && attachments.is_empty()
+            {
                 return Err(FormeError::RenderError(
-                    "PDF/A-2 forbids embedded files that are not themselves PDF/A \
-                     (ISO 19005-2, 6.8). Use a PDF/A-3 level — e.g. pdfa: \"3b\" — \
-                     which permits arbitrary attachments, or remove the attachment / \
-                     embedData."
+                    "pdfa: \"4f\" requires at least one embedded file (ISO 19005-4, \
+                     Annex A; veraPDF 6.9-t5 — the EmbeddedFiles name tree must exist). \
+                     Add an attachment or embedData, or claim pdfa: \"4\" instead."
                         .to_string(),
                 ));
             }

--- a/engine/src/pdf/xmp.rs
+++ b/engine/src/pdf/xmp.rs
@@ -54,18 +54,28 @@ pub fn generate_xmp(
     // Build conformance entries
     let mut entries = String::new();
     if let Some(conf) = conformance {
+        // Part 4 identification, per veraPDF's PDFA-4/PDFA-4F rules read
+        // verbatim: part 4 + REQUIRED pdfaid:rev "2020"; base A-4 "shall
+        // not provide any pdfaid:conformance"; A-4f provides "F".
         let (part, level) = match conf {
-            PdfAConformance::A2a => ("2", "A"),
-            PdfAConformance::A2b => ("2", "B"),
-            PdfAConformance::A2u => ("2", "U"),
-            PdfAConformance::A3a => ("3", "A"),
-            PdfAConformance::A3b => ("3", "B"),
-            PdfAConformance::A3u => ("3", "U"),
+            PdfAConformance::A2a => ("2", Some("A")),
+            PdfAConformance::A2b => ("2", Some("B")),
+            PdfAConformance::A2u => ("2", Some("U")),
+            PdfAConformance::A3a => ("3", Some("A")),
+            PdfAConformance::A3b => ("3", Some("B")),
+            PdfAConformance::A3u => ("3", Some("U")),
+            PdfAConformance::A4 => ("4", None),
+            PdfAConformance::A4f => ("4", Some("F")),
         };
-        entries.push_str(&format!(
-            "      <pdfaid:part>{}</pdfaid:part>\n      <pdfaid:conformance>{}</pdfaid:conformance>\n",
-            part, level
-        ));
+        entries.push_str(&format!("      <pdfaid:part>{part}</pdfaid:part>\n"));
+        if let Some(level) = level {
+            entries.push_str(&format!(
+                "      <pdfaid:conformance>{level}</pdfaid:conformance>\n"
+            ));
+        }
+        if matches!(conf, PdfAConformance::A4 | PdfAConformance::A4f) {
+            entries.push_str("      <pdfaid:rev>2020</pdfaid:rev>\n");
+        }
     }
     if pdf_ua {
         entries.push_str("      <pdfuaid:part>1</pdfuaid:part>\n");

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -12777,3 +12777,83 @@ fn pdf17_output_is_byte_identical_with_the_version_field_present() {
     assert_eq!(a, b, "explicit 1.7 must be byte-identical to the default");
     assert!(a.starts_with(b"%PDF-1.7"));
 }
+
+// ── PDF/A-4 (ISO 19005-4:2020) ──────────────────────────────────────────
+
+fn doca4(level: &str, extra: &str) -> String {
+    format!(
+        r#"{{ "children": [ {{ "kind": {{ "type": "Text", "content": "archival 2.0" }}, "style": {{ "fontFamily": "Noto Sans" }}, "children": [] }} ],
+            "metadata": {{ "title": "A4 Doc" }}, "pdfa": "{level}"{extra} }}"#
+    )
+}
+
+#[test]
+fn pdfa4_identification_and_implied_version() {
+    // veraPDF's PDFA-4 rules, read verbatim: pdfaid:part 4, REQUIRED
+    // pdfaid:rev "2020", and base A-4 "shall not provide any
+    // pdfaid:conformance". Claiming A-4 implies the 2.0 header — a 1.7
+    // header would falsify the claim.
+    let bytes = forme::render_json(&doca4("4", "")).expect("A-4 doc renders");
+    assert!(bytes.starts_with(b"%PDF-2.0"), "A-4 implies the 2.0 header");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("<pdfaid:part>4</pdfaid:part>"));
+    assert!(text.contains("<pdfaid:rev>2020</pdfaid:rev>"));
+    assert!(
+        !text.contains("pdfaid:conformance"),
+        "base A-4 must not provide a conformance property"
+    );
+    assert!(!text.contains("/Info "), "no trailer /Info under A-4");
+    assert!(
+        text.contains("/OutputIntent"),
+        "device color needs an output intent"
+    );
+}
+
+#[test]
+fn pdfa4f_conformance_f_and_attachments() {
+    // A-4f: pdfaid:conformance F, arbitrary embedded files allowed.
+    let bytes = forme::render_json(&doca4(
+        "4f",
+        r#", "attachments": [ { "name": "data.csv", "src": "YSxiCjEsMg==", "mimeType": "text/csv", "relationship": "Supplement" } ]"#,
+    ))
+    .expect("A-4f doc with attachment renders");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(text.contains("<pdfaid:part>4</pdfaid:part>"));
+    assert!(text.contains("<pdfaid:conformance>F</pdfaid:conformance>"));
+    assert!(text.contains("<pdfaid:rev>2020</pdfaid:rev>"));
+    assert!(
+        text.contains("/EmbeddedFiles"),
+        "4f requires the EmbeddedFiles name tree"
+    );
+    assert!(text.contains("/AFRelationship"));
+}
+
+#[test]
+fn pdfa4_base_refuses_attachments_by_name() {
+    // Base A-4 allows only PDF/A-compliant embedded files — which the
+    // engine cannot verify, so it refuses with the remedy (the A-2
+    // rationale, extended).
+    let e = forme::render_json(&doca4(
+        "4",
+        r#", "attachments": [ { "name": "data.csv", "src": "YSxiCjEsMg==", "mimeType": "text/csv", "relationship": "Supplement" } ]"#,
+    ))
+    .unwrap_err();
+    let msg = e.to_string();
+    assert!(
+        msg.contains("4f"),
+        "the refusal must point at the 4f remedy: {msg}"
+    );
+}
+
+#[test]
+fn pdfa4f_without_files_is_refused() {
+    // veraPDF PDFA-4F 6.9-t5, verbatim: "A PDF/A-4f conforming file shall
+    // contain an EmbeddedFiles key" — the claim with nothing embedded is
+    // itself non-conformant, so the engine refuses with the remedy.
+    let e = forme::render_json(&doca4("4f", "")).unwrap_err();
+    let msg = e.to_string();
+    assert!(
+        msg.contains("at least one embedded file") && msg.contains("\"4\""),
+        "must explain and point at plain A-4: {msg}"
+    );
+}

--- a/html/src/lib.rs
+++ b/html/src/lib.rs
@@ -856,8 +856,22 @@ pub fn html_to_document(html: &str, options: &HtmlOptions) -> (forme::Document, 
                 doc.pdfa = Some(PdfAConformance::A3a);
                 doc.tagged = true;
             }
+            // Part 4 (ISO 19005-4:2020, PDF 2.0): no a/b/u split — and NO
+            // accessibility requirement; that moved wholly to PDF/UA-2.
+            // Claiming 4/4f implies pdfVersion 2.0 in the engine.
+            "4" => doc.pdfa = Some(PdfAConformance::A4),
+            // A-4f REQUIRES an embedded file (veraPDF 6.9-t5) and the
+            // HTML path has no attachments option yet — claiming it here
+            // could only ever produce the engine's refusal. Warn with the
+            // real path instead of passing through to a guaranteed error.
+            "4f" => warnings.push(
+                "pdf_a: \"4f\" requires an embedded file and the HTML path has no \
+                 attachments option yet — use pdfa: \"4\" here, or render via \
+                 @formepdf/core (which takes attachments) for 4f. Ignoring."
+                    .to_string(),
+            ),
             other => warnings.push(format!(
-                "pdf_a: unknown conformance level {other:?} — expected \"2b\", \"2u\", \"2a\", \"3b\", \"3u\", or \"3a\". Ignoring."
+                "pdf_a: unknown conformance level {other:?} — expected \"2b\", \"2u\", \"2a\", \"3b\", \"3u\", \"3a\", \"4\", or \"4f\". Ignoring."
             )),
         }
         // PDF/A needs embedded fonts too; if the doc has a language for pdf_ua

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`pdf_a: "4"`** — PDF/A-4 (ISO 19005-4:2020, PDF 2.0) through the HTML path. Implies PDF 2.0 output: every font must be embedded (the standard-14 provision is gone in ISO 32000-2), so register fonts or `fonts-standard`. **PDF/A-4 is not an accessibility claim** — tagging levels moved wholly to PDF/UA-2; for archival + accessible today use `pdf_a: "2a"` + `pdf_ua`. `"4f"` is refused by name until the HTML path grows an attachments option (an A-4f file requires at least one embedded file).
+
 ### Changed (engine behavior visible through the HTML path)
 
 - **Baselines use real font metrics** (see the engine changelog): every text baseline rises by `fs*(1 - ascent + descent)/2` for its font (~0.15em for Helvetica-class faces); line boxes, wrapping, and page breaks are unchanged. The line-height box-centering idiom (`line-height` equal to a box height) now centers glyphs the way a browser does — the repo templates' optical-centering workarounds were removed in the same change.

--- a/packages/preact/src/serialize.ts
+++ b/packages/preact/src/serialize.ts
@@ -228,6 +228,7 @@ export function serialize(element: ReactElement): FormeDocument {
   if (props.style) result.defaultStyle = mapStyle(props.style);
   if (props.tagged !== undefined) result.tagged = props.tagged;
   if (props.pdfa !== undefined) result.pdfa = props.pdfa;
+  if (props.pdfVersion !== undefined) result.pdfVersion = props.pdfVersion;
   if (props.pdfUa) result.pdfUa = true;
   const cert = props.certification ?? props.signature;
   if (cert) {
@@ -1135,6 +1136,7 @@ export function serializeTemplate(element: ReactElement): Record<string, unknown
   if (props.style) result.defaultStyle = mapStyle(props.style);
   if (props.tagged !== undefined) result.tagged = props.tagged;
   if (props.pdfa !== undefined) result.pdfa = props.pdfa;
+  if (props.pdfVersion !== undefined) result.pdfVersion = props.pdfVersion;
   if (props.pdfUa) result.pdfUa = true;
   const cert = props.certification ?? props.signature;
   if (cert) {

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -73,7 +73,9 @@ export interface DocumentProps {
   /** Whether to produce a tagged (accessible) PDF with structure tree. */
   tagged?: boolean;
   /** PDF/A conformance level. "2a" requires tagging, "2b" is visual-only compliance. */
-  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u';
+  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u' | '4' | '4f';
+  /** Output PDF version. "2.0" (ISO 32000-2) requires every font embedded; pdfa "4"/"4f" imply it. Default "1.7". */
+  pdfVersion?: '1.7' | '2.0';
   /** When true, the PDF claims PDF/UA-1 conformance. Forces tagging. */
   pdfUa?: boolean;
   /** Digital certification configuration. Certifies the PDF with an X.509 certificate. */

--- a/packages/react/src/serialize.ts
+++ b/packages/react/src/serialize.ts
@@ -217,6 +217,7 @@ export function serialize(element: ReactElement): FormeDocument {
   if (props.style) result.defaultStyle = mapStyle(props.style);
   if (props.tagged !== undefined) result.tagged = props.tagged;
   if (props.pdfa !== undefined) result.pdfa = props.pdfa;
+  if (props.pdfVersion !== undefined) result.pdfVersion = props.pdfVersion;
   if (props.pdfUa) result.pdfUa = true;
   const cert = props.certification ?? props.signature;
   if (cert) {
@@ -1124,6 +1125,7 @@ export function serializeTemplate(element: ReactElement): Record<string, unknown
   if (props.style) result.defaultStyle = mapStyle(props.style);
   if (props.tagged !== undefined) result.tagged = props.tagged;
   if (props.pdfa !== undefined) result.pdfa = props.pdfa;
+  if (props.pdfVersion !== undefined) result.pdfVersion = props.pdfVersion;
   if (props.pdfUa) result.pdfUa = true;
   const cert = props.certification ?? props.signature;
   if (cert) {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -74,7 +74,9 @@ export interface DocumentProps {
   tagged?: boolean;
   /** PDF/A conformance level. "2b" is visual-only, "2u" adds a Unicode
    *  mapping for all text, "2a" additionally requires full tagging. */
-  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u';
+  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u' | '4' | '4f';
+  /** Output PDF version. "2.0" (ISO 32000-2) requires every font embedded; pdfa "4"/"4f" imply it. Default "1.7". */
+  pdfVersion?: '1.7' | '2.0';
   /** When true, the PDF claims PDF/UA-1 conformance. Forces tagging. */
   pdfUa?: boolean;
   /** Digital certification configuration. Certifies the PDF with an X.509 certificate. */

--- a/packages/shared/src/parser.ts
+++ b/packages/shared/src/parser.ts
@@ -100,7 +100,8 @@ interface DocumentProps {
   lang?: string;
   style?: Style;
   tagged?: boolean;
-  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u';
+  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u' | '4' | '4f';
+  pdfVersion?: '1.7' | '2.0';
   pdfUa?: boolean;
   certification?: CertificationConfig;
   /** @deprecated Use certification */
@@ -162,6 +163,7 @@ export function parseMarkup(markup: string): FormeDocument {
   if (props.style) result.defaultStyle = mapStyle(props.style);
   if (props.tagged !== undefined) result.tagged = props.tagged;
   if (props.pdfa !== undefined) result.pdfa = props.pdfa;
+  if (props.pdfVersion !== undefined) result.pdfVersion = props.pdfVersion;
   if (props.pdfUa) result.pdfUa = true;
   const cert = props.certification ?? props.signature;
   if (cert) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -335,7 +335,23 @@ export interface FormeDocument {
   defaultStyle?: FormeStyle;
   fonts?: FormeFont[];
   tagged?: boolean;
-  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u';
+  /**
+   * PDF/A archival conformance. 2x/3x are the PDF 1.7 (ISO 32000-1)
+   * levels; '4' and '4f' are ISO 19005-4:2020 over PDF 2.0 — claiming
+   * them implies pdfVersion "2.0" and requires every font embedded.
+   * NOTE: PDF/A-4 is NOT an accessibility claim — the a/b/u split is
+   * gone and tagging requirements moved wholly to PDF/UA-2.
+   */
+  pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u' | '4' | '4f';
+  /**
+   * Output PDF version, default "1.7" (today's writer, byte-for-byte).
+   * "2.0" writes ISO 32000-2: XMP metadata always, no trailer /Info,
+   * and EVERY FONT MUST BE EMBEDDED — PDF 2.0 removes the standard-14
+   * provision, so the base-14 defaults (Helvetica etc.) hard-error
+   * unless @formepdf/fonts-standard (or your own fonts) are registered.
+   * 1.7-based claims (pdfa 2x/3x, pdfUa) are errors under "2.0".
+   */
+  pdfVersion?: '1.7' | '2.0';
   pdfUa?: boolean;
   flattenForms?: boolean;
   certification?: CertificationConfig;

--- a/packages/svelte/src/components/Document.svelte
+++ b/packages/svelte/src/components/Document.svelte
@@ -15,7 +15,9 @@
     /** Whether to produce a tagged (accessible) PDF with structure tree. */
     tagged?: boolean;
     /** PDF/A conformance level. "2a" requires tagging, "2b" is visual-only compliance. */
-    pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u';
+    pdfa?: '2a' | '2b' | '2u' | '3a' | '3b' | '3u' | '4' | '4f';
+    /** Output PDF version. "2.0" (ISO 32000-2) requires every font embedded; pdfa "4"/"4f" imply it. Default "1.7". */
+    pdfVersion?: '1.7' | '2.0';
     /** When true, the PDF claims PDF/UA-1 conformance. Forces tagging. */
     pdfUa?: boolean;
     /** Digital certification configuration. Certifies the PDF with an X.509 certificate. */

--- a/packages/vue/src/components/Document.vue
+++ b/packages/vue/src/components/Document.vue
@@ -5,7 +5,7 @@ import { encodeProps } from '../encode.js';
 // stay undefined and are omitted, matching the React/Svelte serializers).
 // `style` is declared here so Vue never treats it as the DOM style attribute.
 defineOptions({ inheritAttrs: false });
-const props = defineProps(['title', 'author', 'subject', 'creator', 'lang', 'style', 'tagged', 'pdfa', 'pdfUa', 'certification', 'signature', 'fonts']);
+const props = defineProps(['title', 'author', 'subject', 'creator', 'lang', 'style', 'tagged', 'pdfa', 'pdfVersion', 'pdfUa', 'certification', 'signature', 'fonts']);
 </script>
 
 <template>

--- a/scripts/verify-pdfa.mjs
+++ b/scripts/verify-pdfa.mjs
@@ -32,7 +32,7 @@ import { renderHtml } from '@formepdf/html';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FIXTURES = join(HERE, '..', 'html', 'tests', 'fixtures');
 const LANG = 'en-US';
-const LEVELS = ['2b', '2a', '3b', '3a']; // 2a/3a additionally require tagging; 2u/3u sit between (same machinery, validated via 3b/3a).
+const LEVELS = ['2b', '2a', '3b', '3a', '4', '4f']; // 2a/3a additionally require tagging; 2u/3u sit between (same machinery, validated via 3b/3a). 4/4f are the ISO 19005-4 (PDF 2.0) levels — no a/b/u split, no accessibility requirement (that moved to PDF/UA-2).
 
 const CORE_FONTS = standardFonts().map((f) => ({
   family: f.family, src: Buffer.from(f.src).toString('base64'),
@@ -50,9 +50,15 @@ const HTML_FIXTURES = ['letterhead', 'dashed-borders', 'statement', 'zebra-invoi
 
 async function renderTemplate(name, data, level) {
   const doc = serialize(getTemplate(name)(data));
-  doc.pdfUa = true;
+  doc.pdfUa = !level.startsWith('4'); // UA-1 is 1.7-based; the 4/4f compose partner is PDF/UA-2 (not yet built)
   doc.tagged = true;
   doc.pdfa = level;
+  // A-4f REQUIRES an embedded file (veraPDF 6.9-t5) — and carrying one
+  // exercises the whole 4f filespec chain (F/UF, MIME Subtype,
+  // AFRelationship, EmbeddedFiles tree) under validation.
+  if (level === '4f') {
+    doc.attachments = [{ name: 'gate.csv', src: Buffer.from('a,b\n1,2\n').toString('base64'), mimeType: 'text/csv', relationship: 'Supplement' }];
+  }
   doc.metadata = { ...(doc.metadata ?? {}), lang: LANG };
   doc.fonts = CORE_FONTS;
   const { pdf } = await renderPdfWithLayout(JSON.stringify(doc));
@@ -60,7 +66,11 @@ async function renderTemplate(name, data, level) {
 }
 async function renderFixture(name, level) {
   const html = await readFile(join(FIXTURES, `${name}.html`), 'utf8');
-  const { pdf } = renderHtml(html, { pdfUa: true, pdfA: level, lang: LANG, fonts: HTML_FONTS });
+  const opts = { pdfUa: !level.startsWith('4'), pdfA: level, lang: LANG, fonts: HTML_FONTS };
+  if (level === '4f') {
+    opts.attachments = [{ name: 'gate.csv', src: Buffer.from('a,b\n1,2\n').toString('base64'), mimeType: 'text/csv', relationship: 'Supplement' }];
+  }
+  const { pdf } = renderHtml(html, opts);
   return pdf;
 }
 
@@ -85,7 +95,9 @@ async function main() {
       id: `a${level}`,
       level,
       label: `PDF/A-${level} + PDF/UA-1`,
-      render: `pdfa:${level} + pdfUa + fonts-standard`,
+      render: level.startsWith('4')
+        ? `pdfa:${level} + fonts-standard (PDF 2.0; accessibility is PDF/UA-2 territory, not composed here)`
+        : `pdfa:${level} + pdfUa + fonts-standard`,
       profiles: [level, 'ua1'],
     })),
     results: [],
@@ -97,13 +109,22 @@ async function main() {
       const p = join(outDir, `${level}-template-${name}.pdf`); writeFileSync(p, pdf);
       corpus.push({ label: `template/${name}`, path: p });
     }
-    for (const name of HTML_FIXTURES) {
-      const pdf = await renderFixture(name, level);
-      const p = join(outDir, `${level}-html-${name}.pdf`); writeFileSync(p, pdf);
-      corpus.push({ label: `html/${name}`, path: p });
+    // The HTML path has no attachments option, and A-4f requires an
+    // embedded file (6.9-t5) — html fixtures validate at every level
+    // except 4f, where the option itself is refused by the html layer.
+    if (level !== '4f') {
+      for (const name of HTML_FIXTURES) {
+        const pdf = await renderFixture(name, level);
+        const p = join(outDir, `${level}-html-${name}.pdf`); writeFileSync(p, pdf);
+        corpus.push({ label: `html/${name}`, path: p });
+      }
     }
     // One JVM per profile over the whole corpus (was one per file*profile).
-    for (const profile of [level, 'ua1']) {
+    // 4/4f validate against their own flavour only: UA-1 is defined over
+    // 1.7 and the engine refuses the combination; the 2.0 accessibility
+    // compose partner is PDF/UA-2, gated when that campaign lands.
+    const profiles = level.startsWith('4') ? [level] : [level, 'ua1'];
+    for (const profile of profiles) {
       const batch = veraValidateBatch(vera, profile, corpus.map((c) => c.path));
       for (const c of corpus) {
         const r = batch.get(c.path) ?? { pass: false, failedClauses: [] };


### PR DESCRIPTION
Campaign PR 2 of 2, stacked on #100. Built against veraPDF's shipped rule set throughout — which paid twice: `pdfaid:rev "2020"` is a required property my Phase 0 spec summary missed, and clause 6.9-t5 (found when the gate corpus failed wholesale) makes an attachment-less A-4f file itself non-conformant, now an engine refusal by name.

- `pdfa: "4" | "4f"`, implying PDF 2.0 at the write boundary; identification exactly per profile (part 4, rev 2020, conformance only F).
- Base A-4 refuses attachments (family-aware A-2 rationale); A-4f refuses *no* attachments.
- Gate: all six PDF/A levels validate over the standing corpus locally — 4f renders carry a CSV so the full filespec chain validates; ua1 cross-check restricted to 1.7 levels.
- Surfaces: TS types + react passthrough + html `pdf_a: "4"` (`"4f"` refused by name until the HTML path has attachments).
- Docs carry the two loud notes: **every font must be embedded under 2.0**, and **PDF/A-4 is not an accessibility claim** — no Level A exists; accessibility moved wholly to PDF/UA-2.

**Acceptance: `isCompliant="true"` under `verapdf -f 4` and `-f 4f`, first try.** Engine 581 green, html 235 green, clippy (incl. visual-tests) clean, docs manifest regenerated.