### PR TITLE
Factur-X via a PDP: verified worked example + docs guide + pdfa-alone font fix

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,6 +138,7 @@
       {
         "group": "Guides",
         "pages": [
+          "guides/e-invoicing-with-a-pdp",
           "guides/migrating-to-0-9",
           "guides/bring-your-own-ui",
           "migrating-from-react-pdf",

--- a/docs/einvoicing.mdx
+++ b/docs/einvoicing.mdx
@@ -7,7 +7,10 @@ A hybrid e-invoice (Factur-X in France, ZUGFeRD in Germany) is a PDF/A-3
 file that people can read, carrying a machine-readable EN 16931 invoice XML
 as an embedded attachment. Forme builds the **container**: you supply the
 XML, Forme renders the human-readable PDF and embeds the XML conformantly
-in the same render call.
+in the same render call. (No XML of your own? A PDP or conversion service
+can build the Factur-X from your rendered PDF plus invoice data — that
+pipeline, run and verified end to end, is the
+[e-invoicing with a PDP guide](/guides/e-invoicing-with-a-pdp).)
 
 ```tsx
 import { renderDocument } from '@formepdf/core';

--- a/docs/guides/e-invoicing-with-a-pdp.mdx
+++ b/docs/guides/e-invoicing-with-a-pdp.mdx
@@ -1,0 +1,250 @@
+---
+title: "E-invoicing with a PDP or conversion service"
+description: "A worked pipeline: Forme renders the invoice as validated PDF/A-3, an e-invoicing service embeds the EN 16931 XML, and the result is a Factur-X that passes both veraPDF and Mustang."
+---
+
+A hybrid e-invoice (Factur-X in France, ZUGFeRD in Germany) is a PDF/A-3
+file that people can read, carrying a machine-readable EN 16931 invoice
+XML as an embedded attachment. The PDF must be PDF/A-3 because that is
+the archival profile that permits arbitrary embedded files — PDF/A-2
+forbids them — and every Factur-X profile requires it.
+
+The problem splits into two halves that different tools own:
+
+1. **A conformant container** — a PDF/A-3 with embedded fonts and the
+   attachment slot. This is Forme's half, verified by veraPDF in CI.
+2. **Standards-compliant invoice XML** — the EN 16931 semantic model,
+   its ~170 business terms, and the several hundred business rules over
+   them. This half comes from a PDP (in France, a *Plateforme de
+   Dématérialisation Partenaire*), an e-invoicing service, or your own
+   EN 16931 implementation.
+
+If you already generate the XML yourself, Forme can embed it directly in
+the render call — that one-pass path is the [E-invoicing
+page](/einvoicing). This guide is the other arrangement, common when a
+PDP handles the regulatory side: **you send the service a PDF and the
+invoice data, and it returns the Factur-X.** Any service with that shape
+fits. The worked example below uses [SuperPDP](https://superpdp.tech)
+because its API is public and documents the conversion call precisely;
+nothing about the pipeline is specific to it.
+
+The full example is runnable from the Forme repo:
+[`examples/factur-x-pdp/`](https://github.com/formepdf/forme/tree/main/examples/factur-x-pdp).
+Everything below was executed against the live endpoint on
+2026-09-11 and verified with veraPDF 1.30.2 and Mustangproject 2.26.0;
+the one thing that did not verify is called out where it happened.
+
+## The pipeline
+
+```
+your invoice data
+      │
+      ├──────────────► EN 16931 semantic model (JSON or CII XML)
+      │                        │
+      ▼                        │
+Forme renders PDF/A-3b         │
+(fonts embedded,               │
+ veraPDF-checked locally)      │
+      │                        │
+      ▼                        ▼
+   POST multipart: pdf + invoice ──► conversion service ──► Factur-X
+                                                              │
+                                                              ▼
+                                            verify: veraPDF (PDF/A-3b)
+                                                  + Mustang (EN 16931)
+```
+
+The point of rendering PDF/A-3b *before* the call is that the container
+is already conformant when the service sees it — fonts embedded, sRGB
+output intent, XMP identification — and you have validated that claim in
+your own process rather than trusting anyone's marketing, theirs or
+ours.
+
+## Step 1 — map your data to EN 16931
+
+This is the part everyone has to do and nobody documents. The example
+starts from the [invoice template](/templates/invoice-standard)'s own
+data shape and maps it to the EN 16931 semantic model (the field names
+below are SuperPDP's JSON encoding of it; every field is annotated with
+its EN 16931 business term, so the mapping transfers to any encoding):
+
+| Template field | EN 16931 | Business term |
+|---|---|---|
+| `document.number` | `number` | BT-1 |
+| `document.issued` | `issue_date` (ISO date) | BT-2 |
+| — (implied by "invoice") | `type_code: 380` (UNTDID 1001) | BT-3 |
+| — (implied by currency symbol) | `currency_code` | BT-5 |
+| `document.due` | `payment_due_date` | BT-9 |
+| `document.terms` | `payment_terms` | BT-20 |
+| `document.customerPo` | `purchase_order_reference` | BT-13 |
+| `issuer.name` / address | `seller.name`, `seller.postal_address` | BT-27, BG-5 |
+| `issuer.email` | `seller.electronic_address` | BT-34 |
+| `billTo` | `buyer.name`, `buyer.postal_address` | BT-44, BG-8 |
+| `shipTo` | `deliver_to_address` | BG-15 |
+| `items[].item` | `lines[].identifier` | BT-126 |
+| `items[].description` | `lines[].item_information.name` | BT-153 |
+| `items[].qty` / `unit` | `invoiced_quantity` + UN/ECE unit code | BT-129, BT-130 |
+| `items[].rate` | `price_details.item_net_price` | BT-146 |
+| `items[].amount` | `lines[].net_amount` | BT-131 |
+| `totals.subtotal` | `totals.sum_invoice_lines_amount`, `total_without_vat` | BT-106, BT-109 |
+| `totals.tax` | `totals.total_vat_amount` | BT-110 |
+| `totals.total` / `amountDue` | `total_with_vat`, `amount_due_for_payment` | BT-112, BT-115 |
+
+Fields with **no equivalent** in the standard: presentation strings like
+the template's `eyebrow` label stay on the PDF only, which is fine — the
+XML is the machine-readable half, not a transcript of the layout.
+
+Fields the **standard requires that a typical invoice template does not
+carry** — this is where the real work is:
+
+- **`process_control.specification_identifier`** (BT-24): the literal
+  `urn:cen.eu:en16931:2017`, naming which rule set the invoice claims.
+- **A VAT breakdown by rate** (BG-23): taxable amount, tax amount, and
+  category code per rate. A display total like "tax: 863.75" is not
+  enough; the standard wants the rate-by-rate decomposition so the
+  receiver can reconcile it.
+- **A VAT category code per line** (BT-151): `S` for standard rate,
+  `E` exempt, and so on — per line, not per invoice.
+- **Structured party identifiers**: country codes on every address,
+  and a seller identifier the buyer can resolve (BR-CO-26 requires
+  BT-29, BT-30 or BT-31 — a registration or VAT identifier, not just a
+  name).
+
+### The jurisdiction layer
+
+The EN 16931 core is not the end of it. Converting through a French PDP,
+the endpoint also enforced the **French CTC profile** on top — every one
+of these was a real rejection the example hit before it passed:
+
+- Seller SIREN, exactly 9 digits (BR-FR-10), and a buyer electronic
+  address for routing (BR-FR-12) — the example uses the SIREN with EAS
+  scheme `0002` for both parties.
+- Three mandatory notes (BG-1) with subject codes: late-payment
+  penalties (`PMD`), the statutory €40 recovery indemnity (`PMT`), and
+  the early-payment discount mention (`AAB`) (BR-FR-05). French
+  invoices carry these sentences by law; the standard makes them data.
+- A billing-mode code in `process_control.business_process_type`
+  (BR-FR-08), `B1` for ordinary goods invoicing.
+- VAT rates from the French rate list (BR-FR-16) — the schematron
+  rejects a rate that is not an actual French rate, so a demonstration
+  invoice with US sales tax cannot pass a French pipeline. The example
+  invoice is accordingly a French one, 20% VAT, with the PDF and the
+  XML agreeing — a hybrid invoice whose two halves disagree is worse
+  than either half alone.
+
+The practical lesson: the service's validation errors are the spec. The
+example's data was corrected entirely by reading the schematron rule
+IDs the endpoint returned (`BR-CO-26`, `CII-SR-470`, `BR-FR-05`…), the
+same validator-first loop Forme's own conformance work uses.
+
+## Step 2 — render the PDF/A-3b
+
+```js
+import { renderHtml } from '@formepdf/html';
+import { standardFonts } from '@formepdf/fonts-standard';
+
+const fonts = standardFonts().map((f) => ({
+  family: f.family, data: f.src, weight: f.fontWeight,
+  italic: f.fontStyle === 'italic',
+}));
+
+const { pdf } = renderHtml(invoiceHtml, { pdfA: '3b', fonts, lang: 'fr' });
+```
+
+`pdfA: '3b'` is the level Factur-X requires; `3b` is sufficient for
+every profile. PDF/A requires embedded fonts, and the base-14 families
+are not embeddable — `@formepdf/fonts-standard` provides
+metric-compatible substitutes the engine embeds in place, so layout is
+byte-identical with or without compliance mode. The JSX path is the
+same idea: `<Document pdfa="3b" fonts={standardFonts()}>`.
+
+The example then runs veraPDF locally and refuses to post a PDF that
+fails its own claim:
+
+```
+pre-flight: veraPDF PDF/A-3b PASS
+```
+
+## Step 3 — the conversion call
+
+The endpoint takes `multipart/form-data` with two parts: the invoice
+(JSON semantic model or raw CII XML) and the PDF.
+
+```js
+const form = new FormData();
+form.append('invoice', new Blob([invoiceJson], { type: 'application/json' }), 'invoice.json');
+form.append('pdf', new Blob([pdf], { type: 'application/pdf' }), 'invoice.pdf');
+
+const res = await fetch(
+  `${BASE}/v1.beta/invoices/convert?from=en16931&to=factur-x`,
+  { method: 'POST', body: form, headers },   // headers: Authorization if your service needs it
+);
+
+if (!res.ok) {
+  const { message } = await res.json();      // 400/500: { http_status_code, message }
+  throw new Error(`conversion failed: ${res.status} — ${message}`);
+}
+const facturX = Buffer.from(await res.arrayBuffer());
+```
+
+A 400 carries the schematron findings verbatim — treat it as the
+validator output it is, not as noise.
+
+**If you generate your own CII XML** the same endpoint takes it in
+place of the JSON: `from=cii`, and the `invoice` part is the XML with
+`type: 'application/xml'`. Nothing else changes. (And if you have the
+XML, also consider [embedding it in the render
+call](/einvoicing) and skipping the service round trip entirely.)
+
+## Step 4 — verify what came back
+
+A returned file is a claim, not a fact. The example runs the result
+through the same two validators Forme's CI uses:
+
+```
+returned file: veraPDF PDF/A-3b PASS
+returned file: Mustang (Factur-X / EN 16931) PASS
+```
+
+Mustang's report for the run: `Parsed PDF: valid, XML: valid, Profile:
+urn:cen.eu:en16931:2017, Errors: []` — the returned Factur-X passed
+PDF/A-3b, the EN 16931 schematron, and the French Flux2 schematron
+Mustang 2.26.0 applies.
+
+One thing did **not** verify, and it is worth stating plainly: sending
+payment instructions (BG-16, a credit transfer with a valid French
+IBAN as BT-84) made the endpoint's own validation reject its CII
+serialization with `[CII-SR-470] Either the IBAN or a Proprietary ID
+(BT-84) shall be used`, in every scheme spelling we tried. BG-16 is
+optional in EN 16931, so the example omits it and the payment details
+stay on the human-readable PDF. If your invoices must carry structured
+payment data through a conversion service, test that path against your
+service before relying on it.
+
+## Alternatives, honestly
+
+- **A PDP or e-invoicing API** (as here): the service owns the XML
+  generation and the regulatory keep-up. In France this is the
+  mandated direction of travel anyway — invoices flow through a PDP.
+- **An EN 16931 library or service that only does XML** — several
+  exist across ecosystems (Mustangproject itself generates as well as
+  validates, on the JVM). You then hold the XML and can use Forme's
+  [one-pass embedding](/einvoicing) with no second service.
+- **In-house EN 16931** — a real project, not a weekend: the semantic
+  model, the CII or UBL serialization, and ongoing schematron
+  maintenance as the rule sets revise. Teams with heavy invoice volume
+  and existing standards expertise do it; most don't need to.
+
+All three end at the same place: XML that validates, inside a PDF/A-3
+that validates.
+
+## What Forme does and does not do
+
+Forme emits the **container**: PDF/A-3 with embedded fonts and a
+conformant embedded-file slot, verified by veraPDF on every commit, plus
+the one-pass Factur-X embedding when you supply the XML. Forme does
+**not** generate EN 16931 XML, and this page's pipeline is not "Factur-X
+support" — the semantic half belongs to the service or library you
+choose. The distinction matters: a conformant container around
+non-conformant XML is not a legal e-invoice, and no PDF library can fix
+that for you.

--- a/docs/images/templates/manifest.json
+++ b/docs/images/templates/manifest.json
@@ -1,122 +1,122 @@
 {
   "invoice-standard": {
-    "hash": "6ed958010feb36e30d93f2cab95ab9883f376a8b9a0f437e0e41d9a797f1fade",
+    "hash": "4ae91075498101f53351a88f095fa6c4b551be77dfd8691049f7128a574d436d",
     "pages": 1
   },
   "invoice-detailed": {
-    "hash": "5fd711fa8e3854427fd8dccd2be6985289713667d25b9f161f2e3839b6573985",
+    "hash": "d47f60ae5f569fabd1247768ced802f6664607e822b8ff8525526226e2824b51",
     "pages": 3
   },
   "credit-note": {
-    "hash": "a677e43181f61105418861a70eac939add4526335420b3d9643c768ee60c3bfd",
+    "hash": "68eddf4fc618883cb97d4e3d0e2ac61b7708f628f0d74c79b94e2eb1c1aebfa2",
     "pages": 1
   },
   "receipt": {
-    "hash": "0d969ff13e8c6150786328bcb85e4a27e898fc074e3de130028c05502562658b",
+    "hash": "aa4adf67b782fc81f986f5919f22fa951e4011cb72b45d59164a3e08f4bad17b",
     "pages": 1
   },
   "quote": {
-    "hash": "1557f4cd0774fa9f017312c16286ae1ff30d27265330a5ed9e9c1babd6ebe711",
+    "hash": "95f39d0c855e35bdce3e77f1b920160666a5dd73d0ff8f1d7ce30ade70a2a50d",
     "pages": 1
   },
   "statement": {
-    "hash": "767fe7c69effb029e5cda073672253d057622f254d7d532dc2f2f2055e70027b",
+    "hash": "afa44a37f0af2ab025ae6aceba6ac1ddf3ef42970a0f27917de2a838aabd4577",
     "pages": 1
   },
   "purchase-order": {
-    "hash": "5a08e7dd41ac8d84682b53df985be1a3a56be9d87d1ff082efd752b56d92d22d",
+    "hash": "deb312121241ffb671245d28115a1cce95e03a45c78bfe26d61ab5df84d6a809",
     "pages": 1
   },
   "remittance-advice": {
-    "hash": "2658a2200a794f23240ada4fb0ee5b0cf2d6282752d892f6c920251336922fc1",
+    "hash": "b5ee79bf48a119b64b1e4ad98c92454c3680c148eb1c8b0f8f18a110e79635db",
     "pages": 1
   },
   "expense-report": {
-    "hash": "c5ac1822db5fc862d61a31a23b0ee4e50433e2ec15365f03cbe19e7d0910017b",
+    "hash": "fac487268546251c485db850d3181eb967fab4391a70de1f0bee4d21ae6545db",
     "pages": 1
   },
   "payslip": {
-    "hash": "0876406f1b4b8f3badfb415215e1ecf4b62b648e52d35161132bc57216843819",
+    "hash": "101217f389ce6c9f8fe16e24739079ae22cb355546545f9b6fd4ea2d40e46f48",
     "pages": 1
   },
   "letterhead": {
-    "hash": "eacff43caaf333ec29017d8972d05fd07b10e021c337105f5cc5a79ec89029c4",
+    "hash": "3f86406457fcd2471e1ef70884f92d3d195660d14ef8c55617fba1b05096915d",
     "pages": 2
   },
   "cover-letter": {
-    "hash": "32629583d00314432deea9e3c05aaba2f2c1df04b2157a15dbeb4e6c8ed0d61f",
+    "hash": "bfaf2e45a6f02e0f93639ee6d0f5f5b43760c0b94f296834cca49ed4ab355338",
     "pages": 1
   },
   "memo": {
-    "hash": "d8c42a7d3b3e9f9867eb1b23ab5f34dcd65c10de271695d89c3ffa60fe758cc0",
+    "hash": "301a576bb2d4afb529d8cf19fd979c55041437a36e6d4db7d2dd0f7140cf9762",
     "pages": 1
   },
   "employment-contract": {
-    "hash": "8a92eb185775d5554d40577e97ffa456a5da6dfad6163a8149315d0eba647ca1",
+    "hash": "2818c536691d765660d8c6488493cd275c8e0f94a997be92683a64603e65c163",
     "pages": 3
   },
   "nda": {
-    "hash": "ddee421365d8017aada69450bb043fa4be6ff1b1557e678c2349d6cba719d075",
+    "hash": "e7ae6d2d39561f72b51b4bb50540f3ed9c3809b5c9139e859ae69f1caa4e50e5",
     "pages": 2
   },
   "service-agreement": {
-    "hash": "f78c73412d8a0de61be7b750836ec2914eae044fba4a5e022e781d6c808c3e79",
+    "hash": "446f778c8761c41af5f20a253dd4bc74f9968eb3a28c552822f12bd95799f53e",
     "pages": 3
   },
   "offer-letter": {
-    "hash": "c0553d419f11bd5b7499921664212becec4262eb540c2fa76ced94580efda9a9",
+    "hash": "a1367c05e6f36f330fe2b159b774600ea063ba3eeadf605943c306533d09dfcc",
     "pages": 1
   },
   "termination-letter": {
-    "hash": "8e0c8d8072e330a267e8eb9b8bbdc60a9baf083c5cef266b628c330b3cff962a",
+    "hash": "57042756069b38f605fb636b913c5a5f85df878f9d1ad4bbb8a10facb46ee5f4",
     "pages": 1
   },
   "reference-letter": {
-    "hash": "179aba2e85dc43aa170525a3ec1cf160b1bff0cbab70eb062fe8ec321e89b50c",
+    "hash": "e2508fd030d70f74e6e156a19b14b483694cd0e659a5cbedab77de8b71f8b298",
     "pages": 1
   },
   "policy-acknowledgement": {
-    "hash": "fb2b954a163883e09d48bc8c5413012afc7bd1c4a6e3e0d7eec7a6ee88a5d2bd",
+    "hash": "f21eba7fdef6d095f19fe3fdcb07a970e2831739e4efed1c04475c2ab8a586a9",
     "pages": 1
   },
   "report-annual": {
-    "hash": "60a8fe5b0d7cdea54cf5b3361f18e2cb9d052e39534fc851880050728a416b06",
+    "hash": "322bd1373f8f72a50d79327542d174b1c615f8d7e9d4b4f87340a68b753a194c",
     "pages": 3
   },
   "report-monthly": {
-    "hash": "c6ecb64f29e93b4736253375cfa3a80424a5d946561388ae92156fcef68185e7",
+    "hash": "78e7dbbcbc99eaa7868528ced17b1894eecbfd68f6974976320a2f033c766e78",
     "pages": 1
   },
   "lab-report": {
-    "hash": "ece679e17e2f189706d4d16b515b3e04ba04d287726e6f02d8b2acb40b7521d0",
+    "hash": "cb01a7588ae0fa6db53bfba7ac58c8c031a7d746dfcdc084ec6f93d55e923b98",
     "pages": 1
   },
   "inspection-report": {
-    "hash": "aaa0b153cd86b32c3d5960b33fe6e781342e1ea81f866db56992b0d71ee3ca9f",
+    "hash": "81c27cdc10050a5c4cbc45370c881920810e3c0e91b84b9fbaf4231212856357",
     "pages": 1
   },
   "shipping-label": {
-    "hash": "054913aa74f91055a1be3132f8df28c31fe12f26088805e204c45f58366ccdb1",
+    "hash": "1bb7b85c899b9154cbea474ef2732ad92aed9215b9c91245f44fe81f200f09ee",
     "pages": 1
   },
   "packing-slip": {
-    "hash": "da94e42e073ebf707f141f03ae86541d60d41865d69227cc040fd8caca5f6cfe",
+    "hash": "a635d69562e0f82a605f56722a0d30e689a2efe2951d52de6ece05a996996a98",
     "pages": 1
   },
   "delivery-note": {
-    "hash": "3fb5990be5abae890c2c34c2f2ad8173196c298fcbddac8a8321f1a7d129d0bd",
+    "hash": "fe4a740d7683c814dbf37847da5f300cfe799436e6168e0a0a5ad630cf44a2e0",
     "pages": 1
   },
   "certificate": {
-    "hash": "73eb61e09cae5c8bb7186037d45d6380789683d00e57b50088db1298de2ee03f",
+    "hash": "513f4c457632bd76b97c115e485b2b559711b5c87390c9fe60f8594b31bdcd26",
     "pages": 1
   },
   "product-catalog": {
-    "hash": "5a80d8cbd899abe8a4fb05a9451afb7276877f3a4db84af0deeb0edf27f55857",
+    "hash": "2874018bc8904249d189b3e132313c573da1b8b4e277b6c1a8f1f925a7c650c9",
     "pages": 2
   },
   "meeting-minutes": {
-    "hash": "63c5f428acd5d8541cff90cecffe44e9e948dea8720604f516598385bb1506ce",
+    "hash": "58b9532ad0fd8b278a92b1f417234a52d40064d200ebcb630f7f34b2c204c938",
     "pages": 1
   }
 }

--- a/engine/CHANGELOG.md
+++ b/engine/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **`pdfa` alone now embeds the fonts-standard substitutes.** The Liberation substitution for base-14 families was gated on `pdfUa` (or PDF 2.0), while pdfa's own embedded-fonts check counts a base-14 family as embedded only via that substitution — so `pdfa` without `pdfUa` errored "'Helvetica' is not [embedded]" even with `@formepdf/fonts-standard` registered. The substitute was registered and never consulted. Found by the Factur-X PDP example, whose pipeline renders `pdfa: "3b"` with no accessibility claim.
+
 ## [0.22.0] - 2026-09-10
 
 ### Added

--- a/engine/src/pdf/mod.rs
+++ b/engine/src/pdf/mod.rs
@@ -331,7 +331,14 @@ impl PdfWriter {
 
         // Register the fonts actually used across all pages
         builder.pdf_version = pdf_version;
-        self.register_fonts(&mut builder, pages, font_context, pdf_ua, pdf_version)?;
+        self.register_fonts(
+            &mut builder,
+            pages,
+            font_context,
+            pdf_ua,
+            pdfa.is_some(),
+            pdf_version,
+        )?;
 
         // PDF/A: validate that all fonts are embedded. A font counts as
         // embedded if the caller registered custom bytes for it OR it's a
@@ -3005,12 +3012,14 @@ impl PdfWriter {
         true
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn register_fonts(
         &self,
         builder: &mut PdfBuilder,
         pages: &[LayoutPage],
         font_context: &FontContext,
         pdf_ua: bool,
+        pdfa: bool,
         pdf_version: crate::model::PdfVersion,
     ) -> Result<(), FormeError> {
         // Collect font usage: glyph IDs, chars, and glyph→char mapping per font
@@ -3055,7 +3064,13 @@ impl PdfWriter {
                     // WinAnsiEncoding — the content stream is untouched (same
                     // `(text) Tj` WinAnsi path, same positions), only the font
                     // dictionary gains an embedded program.
-                    if pdf_ua || pdf_version == crate::model::PdfVersion::V2_0 {
+                    // pdfa alone needs the same substitution: its own
+                    // embedded-fonts check (below the call site) counts a
+                    // base-14 family as embedded ONLY via this path, so
+                    // gating on pdfUa made pdfa-without-pdfUa error even
+                    // with fonts-standard registered — the substitute was
+                    // registered and never consulted.
+                    if pdf_ua || pdfa || pdf_version == crate::model::PdfVersion::V2_0 {
                         if Self::emit_pdfua_embedded_standard(
                             builder,
                             key,

--- a/engine/tests/integration.rs
+++ b/engine/tests/integration.rs
@@ -13208,3 +13208,30 @@ fn align_items_center_respects_max_width() {
         "block centered: x={x}, expected≈{expected} (w={w})"
     );
 }
+
+#[test]
+fn pdfa_alone_embeds_the_standard_font_substitute() {
+    // pdfa's embedded-fonts check counts a base-14 family as embedded only
+    // via the fonts-standard substitution path, but that path was gated on
+    // pdfUa — so pdfa WITHOUT pdfUa errored "'Helvetica' is not [embedded]"
+    // even with the substitute registered. The substitute was registered
+    // and never consulted. Found by the Factur-X PDP example, whose
+    // pipeline renders pdfa "3b" with no accessibility claim.
+    use base64::Engine as _;
+    let font = base64::engine::general_purpose::STANDARD
+        .encode(include_bytes!("../fonts/NotoSans-Regular.ttf"));
+    let json = format!(
+        r#"{{ "children": [
+            {{ "kind": {{ "type": "Text", "content": "Invoice 2026-001" }}, "style": {{}}, "children": [] }}
+        ],
+        "metadata": {{ "title": "A3b Doc" }},
+        "fonts": [{{ "family": "Liberation Sans", "src": "{font}", "weight": 400, "italic": false }}],
+        "pdfa": "3b" }}"#
+    );
+    let bytes = forme::render_json(&json).expect("pdfa 3b + registered substitute renders");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("/FontFile2"),
+        "the substitute is embedded as a font program"
+    );
+}

--- a/examples/factur-x-pdp/README.md
+++ b/examples/factur-x-pdp/README.md
@@ -1,0 +1,38 @@
+# Factur-X via a PDP / conversion service
+
+The runnable example behind
+[docs.formepdf.com/guides/e-invoicing-with-a-pdp](https://docs.formepdf.com/guides/e-invoicing-with-a-pdp):
+Forme renders a French invoice as **PDF/A-3b** (veraPDF-checked before it
+leaves the process), a conversion service embeds the **EN 16931** semantic
+model, and the returned **Factur-X** is verified with veraPDF and
+Mustangproject.
+
+```
+node examples/factur-x-pdp/render-and-convert.mjs
+```
+
+Run from the repo root with packages built (`npm install` at the root,
+then build `packages/shared` → `fonts-standard` → `html` per the build
+order in `/CLAUDE.md`). Outputs land in `out/`.
+
+- `invoice.html` — the invoice, Northmoor's invoice-standard template with
+  French parties, EUR amounts, and 20% VAT, so the human-readable PDF and
+  the machine-readable XML agree.
+- `en16931-invoice.json` — the EN 16931 semantic model for the same
+  invoice (SuperPDP's JSON encoding; every field annotated with its
+  business term in their OpenAPI spec). The mapping table and the French
+  CTC additions are documented on the docs page.
+- `render-and-convert.mjs` — render → pre-flight veraPDF → multipart POST
+  → verify the returned file (veraPDF PDF/A-3b + Mustang).
+
+Env: `SUPERPDP_URL` (default `https://api.superpdp.tech`, whose convert
+endpoint is documented as unauthenticated), `SUPERPDP_TOKEN` (optional
+bearer), `VERAPDF`, `MUSTANG_JAR` (validators; skipped with a notice if
+absent).
+
+Last verified end to end 2026-09-11: pre-flight PASS, conversion 200,
+returned file PASS under veraPDF 1.30.2 (PDF/A-3b) and Mustang 2.26.0
+(EN 16931 + Flux2 schematron, profile `urn:cen.eu:en16931:2017`, zero
+errors). Known finding, stated on the docs page: sending payment
+instructions (BG-16 with a valid IBAN) made the endpoint reject its own
+CII serialization under `CII-SR-470`, so the example omits BG-16.

--- a/examples/factur-x-pdp/en16931-invoice.json
+++ b/examples/factur-x-pdp/en16931-invoice.json
@@ -1,0 +1,159 @@
+{
+  "number": "FA-2026-0417",
+  "issue_date": "2026-09-07",
+  "type_code": 380,
+  "currency_code": "EUR",
+  "payment_due_date": "2026-10-07",
+  "payment_terms": "Net 30 days",
+  "purchase_order_reference": "BC-0091 / 44-7712",
+  "process_control": {
+    "specification_identifier": "urn:cen.eu:en16931:2017",
+    "business_process_type": "B1"
+  },
+  "seller": {
+    "name": "Ateliers Verneuil SARL",
+    "postal_address": {
+      "address_line1": "12 rue de la Fonderie",
+      "city": "Lyon",
+      "post_code": "69003",
+      "country_code": "FR"
+    },
+    "electronic_address": {
+      "value": "842019456",
+      "scheme": "0002"
+    },
+    "legal_registration_identifier": {
+      "value": "842019456",
+      "scheme": "0002"
+    },
+    "vat_identifier": "FR94842019456",
+    "contact": {
+      "email_address": "facturation@ateliers-verneuil.fr"
+    }
+  },
+  "buyer": {
+    "name": "Brasserie du Canal SAS",
+    "postal_address": {
+      "address_line1": "48 quai des Chartrons",
+      "city": "Bordeaux",
+      "post_code": "33000",
+      "country_code": "FR"
+    },
+    "electronic_address": {
+      "value": "512076383",
+      "scheme": "0002"
+    },
+    "legal_registration_identifier": {
+      "value": "512076383",
+      "scheme": "0002"
+    }
+  },
+  "deliver_to_address": {
+    "address_line1": "Entrepôt 2 — Quai de réception 4",
+    "address_line2": "14 rue Lucien-Faure",
+    "city": "Bordeaux",
+    "post_code": "33300",
+    "country_code": "FR"
+  },
+  "lines": [
+    {
+      "identifier": "001",
+      "invoiced_quantity": "1200",
+      "invoiced_quantity_code": "EA",
+      "net_amount": "2220.00",
+      "item_information": {
+        "name": "Fastener set, stainless 316, M8 × 40 mm, hex flange"
+      },
+      "price_details": {
+        "item_net_price": "1.85"
+      },
+      "vat_information": {
+        "invoiced_item_vat_category_code": "S",
+        "invoiced_item_vat_rate": "20"
+      }
+    },
+    {
+      "identifier": "002",
+      "invoiced_quantity": "24",
+      "invoiced_quantity_code": "EA",
+      "net_amount": "1116.00",
+      "item_information": {
+        "name": "Gasket sheet, neoprene, 1/8 in × 36 in × 36 in"
+      },
+      "price_details": {
+        "item_net_price": "46.50"
+      },
+      "vat_information": {
+        "invoiced_item_vat_category_code": "S",
+        "invoiced_item_vat_rate": "20"
+      }
+    },
+    {
+      "identifier": "003",
+      "invoiced_quantity": "6",
+      "invoiced_quantity_code": "EA",
+      "net_amount": "768.00",
+      "item_information": {
+        "name": "Conveyor belt lacing kit, No. 2 rivet, with tooling"
+      },
+      "price_details": {
+        "item_net_price": "128.00"
+      },
+      "vat_information": {
+        "invoiced_item_vat_category_code": "S",
+        "invoiced_item_vat_rate": "20"
+      }
+    },
+    {
+      "identifier": "004",
+      "invoiced_quantity": "1",
+      "invoiced_quantity_code": "EA",
+      "net_amount": "214.75",
+      "item_information": {
+        "name": "Outbound freight — road, Lyon to Bordeaux"
+      },
+      "price_details": {
+        "item_net_price": "214.75"
+      },
+      "vat_information": {
+        "invoiced_item_vat_category_code": "S",
+        "invoiced_item_vat_rate": "20"
+      }
+    }
+  ],
+  "vat_break_down": [
+    {
+      "vat_category_code": "S",
+      "vat_category_rate": "20",
+      "vat_category_taxable_amount": "4318.75",
+      "vat_category_tax_amount": "863.75"
+    }
+  ],
+  "totals": {
+    "sum_invoice_lines_amount": "4318.75",
+    "total_without_vat": "4318.75",
+    "total_vat_amount": {
+      "value": "863.75",
+      "currency_code": "EUR"
+    },
+    "total_with_vat": "5182.50",
+    "amount_due_for_payment": "5182.50"
+  },
+  "notes": [
+    {
+      "note": "Indemnite forfaitaire pour frais de recouvrement en cas de retard de paiement : 40 EUR",
+      "subject_code": "PMT"
+    },
+    {
+      "note": "Penalites de retard : trois fois le taux d'interet legal",
+      "subject_code": "PMD"
+    },
+    {
+      "note": "Pas d'escompte pour paiement anticipe",
+      "subject_code": "AAB"
+    }
+  ],
+  "delivery_information": {
+    "actual_delivery_date": "2026-09-05"
+  }
+}

--- a/examples/factur-x-pdp/invoice.html
+++ b/examples/factur-x-pdp/invoice.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Facture FA-2026-0417 — Ateliers Verneuil SARL</title>
+<link rel="stylesheet" href="../../templates/northmoor-shared.css">
+<link rel="stylesheet" href="../../templates/invoice-standard/style.css">
+</head>
+<body>
+<div class="sheet">
+<div class="atop"></div>
+<div class="pagefill">
+
+<header>
+  <div class="hd">
+    <div class="mast-left">
+      <div class="mark">V</div>
+      <div>
+        <div class="wm">Verneuil</div>
+        <div class="sub" style="margin-top: 3pt">Ateliers Verneuil SARL</div>
+      </div>
+    </div>
+    <div class="addr" style="text-align: right">12 rue de la Fonderie<br>69003 Lyon, France<br>SIREN 842 019 456 · TVA FR94842019456<br>facturation@ateliers-verneuil.fr</div>
+  </div>
+  <div class="hr2 mast-divider"></div>
+
+  <div class="dochead">
+    <div>
+      <div class="lbl lbl-accent" style="margin-bottom: 7.5pt">Accounts receivable</div>
+      <h1 class="dtitle">Invoice</h1>
+    </div>
+    <div style="text-align: right">
+      <div class="lbl" style="margin-bottom: 5.25pt">Invoice number</div>
+      <div class="refnum">FA-2026-0417</div>
+    </div>
+  </div>
+</header>
+
+<div class="meta meta-invoice">
+  <div><div class="lbl">Bill to</div>Brasserie du Canal SAS<br>SIREN 512 076 383<br>48 quai des Chartrons<br>33000 Bordeaux, France</div>
+  <div><div class="lbl">Ship to</div>Brasserie du Canal SAS<br>Entrepôt 2 — Quai de réception 4<br>14 rue Lucien-Faure<br>33300 Bordeaux, France</div>
+  <div><div class="lbl">Issued</div>07 September 2026<div class="lbl meta-gap">Terms</div>Net 30 days</div>
+  <div><div class="lbl">Due</div>07 October 2026<div class="lbl meta-gap">Customer / PO</div>BC-0091 / 44-7712</div>
+</div>
+
+<table class="t items">
+  <thead>
+    <tr>
+      <th scope="col" style="width: 33pt">Item</th>
+      <th scope="col">Description</th>
+      <th scope="col" class="num" style="width: 52.5pt">Qty</th>
+      <th scope="col" style="width: 36pt">Unit</th>
+      <th scope="col" class="num" style="width: 61.5pt">Rate</th>
+      <th scope="col" class="num" style="width: 69pt">Amount</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>001</td><td>Fastener set, stainless 316, M8 × 40 mm, hex flange</td><td class="num">1,200</td><td>ea</td><td class="num">1.85</td><td class="num">2,220.00</td></tr>
+    <tr><td>002</td><td>Gasket sheet, neoprene, 1/8 in × 36 in × 36 in</td><td class="num">24</td><td>sheet</td><td class="num">46.50</td><td class="num">1,116.00</td></tr>
+    <tr><td>003</td><td>Conveyor belt lacing kit, No. 2 rivet, with tooling</td><td class="num">6</td><td>kit</td><td class="num">128.00</td><td class="num">768.00</td></tr>
+    <tr><td>004</td><td>Outbound freight — road, Lyon to Bordeaux</td><td class="num">1</td><td>lot</td><td class="num">214.75</td><td class="num">214.75</td></tr>
+  </tbody>
+</table>
+
+<table class="tt">
+  <tbody>
+    <tr><td>Subtotal</td><td class="num">4,318.75</td></tr>
+    <tr><td>TVA 20.00% on 4,318.75</td><td class="num">863.75</td></tr>
+    <tr class="total"><td>Total</td><td class="num">5,182.50</td></tr>
+  </tbody>
+</table>
+
+<div class="due">
+  <span class="lbl" style="color: #111111">Amount due</span>
+  <span class="due-figure">€5,182.50</span>
+</div>
+
+<div class="pagefill-spacer"></div>
+
+<footer class="foot">
+  <div style="flex: 1"><div class="lbl">Remit to</div>Ateliers Verneuil SARL<br>IBAN FR76 3000 4000 0300 0123 4567 897 · Reference FA-2026-0417</div>
+  <div style="flex: 1"><div class="lbl">Terms</div>Payment due within 30 days of invoice date. Late payment: interest at three times the French legal rate plus the statutory €40 recovery indemnity. No discount for early payment.</div>
+</footer>
+
+</div>
+</div>
+</body>
+</html>

--- a/examples/factur-x-pdp/out/mustang-report.xml
+++ b/examples/factur-x-pdp/out/mustang-report.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<validation filename="factur-x.pdf" datetime="2026-09-11 10:58:08">
+  <pdf>ValidationResult [flavour=3b, totalAssertions=4161, assertions=[], isCompliant=true]
+    <info>
+      <signature>unknown</signature>
+      <duration unit="ms">824</duration>
+    </info>
+    <summary status="valid"/>
+  </pdf>  
+  <xml>
+    <info>
+      <version>2</version>
+      <profile>urn:cen.eu:en16931:2017</profile>
+      <validator version="2.26.0"/>
+      <rules>
+        <fired>82</fired>
+        <failed>0</failed>
+      </rules>
+      <duration unit="ms">775</duration>
+    </info>
+    <summary status="valid"/>
+  </xml>
+  <summary status="valid"/>
+</validation>
+

--- a/examples/factur-x-pdp/render-and-convert.mjs
+++ b/examples/factur-x-pdp/render-and-convert.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Factur-X via a PDP / conversion service — the worked example behind
+// docs.formepdf.com/guides/e-invoicing-with-a-pdp.
+//
+// The pipeline, end to end:
+//   1. Forme renders the Northmoor invoice template as PDF/A-3b — the
+//      conformance level Factur-X requires — with fonts embedded, and
+//      gates it on veraPDF locally BEFORE it leaves the process.
+//   2. The PDF and the EN 16931 semantic model (en16931-invoice.json,
+//      mapped from the template's own data.json — the mapping table is
+//      on the docs page) go to the conversion endpoint as multipart.
+//   3. The returned Factur-X is verified by veraPDF (PDF/A-3b) and
+//      Mustangproject (EN 16931 schematron) — the same two validators
+//      this repo's CI runs. What they report is printed verbatim.
+//
+// The endpoint defaults to SuperPDP's public convert API (its OpenAPI
+// spec documents the call as unauthenticated); any service with the same
+// PDF+data-in, Factur-X-out shape fits — set SUPERPDP_URL, and
+// SUPERPDP_TOKEN if yours needs a bearer token.
+//
+// Run from the repo root (packages must be built — see examples README):
+//   node examples/factur-x-pdp/render-and-convert.mjs
+//
+// Env:
+//   SUPERPDP_URL    conversion service base (default https://api.superpdp.tech)
+//   SUPERPDP_TOKEN  optional bearer token
+//   VERAPDF         veraPDF binary (default ~/verapdf/verapdf; skipped if absent)
+//   MUSTANG_JAR     Mustang CLI jar (default ~/mustang/Mustang-CLI.jar; skipped if absent)
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, '..', '..');
+const OUT = join(HERE, 'out');
+mkdirSync(OUT, { recursive: true });
+
+const { renderHtml } = await import('@formepdf/html');
+const { standardFonts } = await import('@formepdf/fonts-standard');
+
+// ── validators (optional locally, but the run reports what it skipped) ──
+const VERAPDF = process.env.VERAPDF ?? join(homedir(), 'verapdf', 'verapdf');
+const MUSTANG = process.env.MUSTANG_JAR ?? join(homedir(), 'mustang', 'Mustang-CLI.jar');
+
+function veraPdf(flavour, path) {
+  if (!existsSync(VERAPDF)) return { skipped: true };
+  try {
+    const xml = execFileSync(VERAPDF, ['-f', flavour, '--format', 'xml', path], {
+      encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+    });
+    return { pass: /isCompliant="true"/.test(xml) };
+  } catch (e) {
+    // veraPDF exits non-zero on non-compliance but still writes the report.
+    const xml = String(e.stdout ?? '');
+    return { pass: /isCompliant="true"/.test(xml) };
+  }
+}
+
+function mustang(path) {
+  if (!existsSync(MUSTANG)) return { skipped: true };
+  try {
+    const out = execFileSync('java', [
+      '-Xmx1G', '-Dfile.encoding=UTF-8', '-jar', MUSTANG,
+      '--action', 'validate', '--source', path, '--no-notices',
+    ], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    return { pass: /status="valid"/.test(out), report: out };
+  } catch (e) {
+    const out = String(e.stdout ?? '') + String(e.stderr ?? '');
+    return { pass: /status="valid"/.test(out), report: out };
+  }
+}
+
+// ── 1. render the invoice as PDF/A-3b, fonts embedded ──────────────────
+const T = join(ROOT, 'templates');
+const sharedCss = readFileSync(join(T, 'northmoor-shared.css'), 'utf8');
+const ownCss = readFileSync(join(T, 'invoice-standard', 'style.css'), 'utf8');
+const html = readFileSync(join(HERE, 'invoice.html'), 'utf8')
+  .replace('<link rel="stylesheet" href="../../templates/northmoor-shared.css">', `<style>${sharedCss}</style>`)
+  .replace('<link rel="stylesheet" href="../../templates/invoice-standard/style.css">', `<style>${ownCss}</style>`);
+
+const fonts = standardFonts().map((f) => ({
+  family: f.family, data: f.src, weight: f.fontWeight, italic: f.fontStyle === 'italic',
+}));
+
+const { pdf, warnings } = renderHtml(html, { pdfA: '3b', fonts, lang: 'fr' });
+for (const w of warnings ?? []) console.warn('render warning:', w);
+const pdfPath = join(OUT, 'invoice-a3b.pdf');
+writeFileSync(pdfPath, pdf);
+console.log(`rendered ${pdfPath} (${pdf.length} bytes)`);
+
+// The point of the exercise: the container is conformant BEFORE the
+// service sees it. Refuse to post a PDF that fails its own claim.
+const pre = veraPdf('3b', pdfPath);
+if (pre.skipped) console.log('veraPDF not found — pre-flight PDF/A-3b check SKIPPED');
+else if (pre.pass) console.log('pre-flight: veraPDF PDF/A-3b PASS');
+else { console.error('pre-flight: veraPDF PDF/A-3b FAIL — not posting a non-conformant PDF'); process.exit(1); }
+
+// ── 2. post PDF + EN 16931 model, get the Factur-X back ────────────────
+const BASE = process.env.SUPERPDP_URL ?? 'https://api.superpdp.tech';
+const url = `${BASE}/v1.beta/invoices/convert?from=en16931&to=factur-x`;
+const invoiceJson = readFileSync(join(HERE, 'en16931-invoice.json'), 'utf8');
+
+const form = new FormData();
+form.append('invoice', new Blob([invoiceJson], { type: 'application/json' }), 'invoice.json');
+form.append('pdf', new Blob([pdf], { type: 'application/pdf' }), 'invoice-a3b.pdf');
+
+const headers = {};
+if (process.env.SUPERPDP_TOKEN) headers.Authorization = `Bearer ${process.env.SUPERPDP_TOKEN}`;
+
+console.log(`POST ${url}`);
+const res = await fetch(url, { method: 'POST', body: form, headers });
+
+if (!res.ok) {
+  // The spec's error shape: { http_status_code, message } on 400/500.
+  let detail = '';
+  try {
+    const body = await res.json();
+    detail = body.message ?? JSON.stringify(body);
+  } catch { detail = await res.text().catch(() => ''); }
+  console.error(`conversion failed: HTTP ${res.status}${detail ? ` — ${detail}` : ''}`);
+  process.exit(1);
+}
+
+const facturX = Buffer.from(await res.arrayBuffer());
+const outPath = join(OUT, 'factur-x.pdf');
+writeFileSync(outPath, facturX);
+console.log(`received ${outPath} (${facturX.length} bytes, ${res.headers.get('content-type')})`);
+
+// ── 3. verify the returned file — both validators, verdicts verbatim ───
+let failed = false;
+
+const post = veraPdf('3b', outPath);
+if (post.skipped) console.log('veraPDF not found — returned-file PDF/A-3b check SKIPPED');
+else { console.log(`returned file: veraPDF PDF/A-3b ${post.pass ? 'PASS' : 'FAIL'}`); failed ||= !post.pass; }
+
+const m = mustang(outPath);
+if (m.skipped) console.log('Mustang not found — EN 16931 schematron check SKIPPED');
+else { console.log(`returned file: Mustang (Factur-X / EN 16931) ${m.pass ? 'PASS' : 'FAIL'}`); failed ||= !m.pass; }
+if (m.report) writeFileSync(join(OUT, 'mustang-report.xml'), m.report);
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
The complete Forme→PDP→Factur-X pipeline, run end to end against a live conversion endpoint and written down.

## Executed vs written-from-spec

**Everything was executed.** The endpoint's convert call is documented unauthenticated in its public OpenAPI spec and worked as documented, so no part of this is spec-fiction:

- Forme renders the example invoice as PDF/A-3b → **pre-flight veraPDF PASS** (the script refuses to post a non-conformant PDF).
- `POST /v1.beta/invoices/convert?from=en16931&to=factur-x` (multipart: EN 16931 JSON + PDF) → **200**, Factur-X returned.
- Returned file: **veraPDF PDF/A-3b PASS**, **Mustang 2.26.0 PASS** (EN 16931 + Flux2 schematron, profile `urn:cen.eu:en16931:2017`, zero errors). Run date 2026-09-11, stated on the page and in the example README.

## What's in it

- `examples/factur-x-pdp/` — runnable script + French invoice fixture (invoice-standard template, French parties, EUR, 20% VAT so PDF and XML agree) + the mapped EN 16931 model. Env-var driven (`SUPERPDP_URL`/`SUPERPDP_TOKEN`); validators skipped with a notice if absent.
- `docs/guides/e-invoicing-with-a-pdp.mdx` — generic-first (any PDF+data→Factur-X service; SuperPDP as the public-spec instance), the mapping table with the no-equivalent fields and standard-required additions, the French CTC layer (every rule listed was a real rejection hit before it passed), the raw-CII variant, honest alternatives, and the boundary: Forme emits the container, it does not generate EN 16931 XML.
- **One finding reported, not hidden**: sending optional BG-16 payment instructions with a valid IBAN made the endpoint reject its own CII serialization (`CII-SR-470`) in every scheme spelling tried; the example omits BG-16 and the page says so.

## Engine fix the example surfaced

`pdfa` alone + fonts-standard has always errored: the Liberation substitution was gated on `pdfUa`/2.0 while pdfa's embedded-fonts check only counts base-14 families via that substitution — registered and never consulted. Gate now includes pdfa; pin stash-verified fails-first; byte-wall vs main IDENTICAL; 594 engine tests green; clippy strict clean; gallery manifest regenerated.