### PR TITLE
test(python): cover the render_html option surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,49 @@ jobs:
           name: parity-determinism
           path: parity-partials/determinism.json
 
+  python-sdk:
+    name: Python SDK (local WASM tests + byte-parity)
+    runs-on: ubuntu-latest
+    needs: [engine, wasm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine
+            html
+      - name: Add wasip1 target
+        run: rustup target add wasm32-wasip1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Download WASM packages (built once in the wasm job)
+        # Provides the built @formepdf/html target so the Node reference render
+        # (the byte-parity oracle) resolves from the repo root.
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkgs
+          path: packages
+      - name: Install Node deps (for @formepdf/html parity reference)
+        run: npm install
+      - name: Build the Python WASM module (from the html crate)
+        working-directory: packages/python-sdk
+        run: bash build_wasm.sh
+      - name: Install Python deps
+        run: pip install wasmtime pytest
+      - name: Run Python tests (options surface + byte-parity to Node)
+        working-directory: packages/python-sdk
+        env:
+          # Resolve @formepdf/html for the parity oracle from the repo root,
+          # where `npm install` above set up the workspace symlink.
+          FORME_NODE_REF_DIR: ${{ github.workspace }}
+        run: python -m pytest -q
+
   coverage:
     name: Coverage (Rust)
     runs-on: ubuntu-latest

--- a/packages/python-sdk/tests/test_render_html.py
+++ b/packages/python-sdk/tests/test_render_html.py
@@ -1,0 +1,111 @@
+"""Tests for the local HTML->PDF path and its option surface.
+
+Covers `formepdf.render_html(...)` beyond the byte-parity gate: that each
+Pythonic option actually reaches the engine and shapes the output, and that
+failures surface as `FormeRenderError`. Self-contained — no Node, no network.
+"""
+
+import base64
+import pathlib
+
+import pytest
+
+from formepdf import render_html
+from formepdf.wasm import FormeRenderError
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+FONT = REPO_ROOT / "packages" / "fonts-standard" / "fonts" / "LiberationSans-Regular.ttf"
+
+HTML = (
+    "<!doctype html><html lang='en'><head><style>"
+    "body{font-family:'Liberation Sans',sans-serif;font-size:12pt;margin:24pt}"
+    "h1{font-size:20pt}</style></head>"
+    "<body><h1>Statement</h1><p>Amounts in EUR.</p></body></html>"
+)
+
+
+def _pdf_ok(pdf: bytes) -> None:
+    assert isinstance(pdf, (bytes, bytearray))
+    assert pdf[:5] == b"%PDF-"
+    assert len(pdf) > 500
+
+
+def test_render_html_default_produces_pdf():
+    _pdf_ok(render_html(HTML))
+
+
+def test_page_size_changes_output():
+    a4 = render_html(HTML, page_size="A4")
+    letter = render_html(HTML, page_size="Letter")
+    _pdf_ok(a4)
+    _pdf_ok(letter)
+    # Different media boxes => different bytes.
+    assert a4 != letter
+
+
+def test_unknown_page_size_raises():
+    with pytest.raises(FormeRenderError):
+        render_html(HTML, page_size="Postcard")
+
+
+def test_css_injection_changes_output():
+    base = render_html(HTML)
+    withcss = render_html(HTML, css="h1{font-size:40pt}")
+    _pdf_ok(withcss)
+    assert base != withcss
+
+
+def test_pdfa_with_embedded_font_is_pdfa():
+    font = FONT.read_bytes()
+    pdf = render_html(
+        HTML,
+        pdfa="2b",
+        lang="en",
+        fonts=[{"family": "Liberation Sans", "data": font, "weight": 400, "italic": False}],
+    )
+    _pdf_ok(pdf)
+    # PDF/A stamps a pdfaid marker in the XMP metadata.
+    assert b"pdfaid" in pdf, "PDF/A output is missing its pdfaid XMP marker"
+
+
+def test_pdfa_without_embeddable_font_raises():
+    # PDF/A requires all fonts embedded; a base-14 family that isn't supplied
+    # must fail loudly rather than emit a non-conforming file.
+    with pytest.raises(FormeRenderError):
+        render_html(
+            "<html lang='en'><body><p style=\"font-family:Helvetica\">x</p></body></html>",
+            pdfa="2b",
+            lang="en",
+        )
+
+
+def test_pdf_ua_produces_tagged_structure():
+    font = FONT.read_bytes()
+    pdf = render_html(
+        HTML,
+        pdf_ua=True,
+        lang="en",
+        fonts=[{"family": "Liberation Sans", "data": font, "weight": 400, "italic": False}],
+    )
+    _pdf_ok(pdf)
+    # PDF/UA requires a tagged structure tree.
+    assert b"StructTreeRoot" in pdf, "PDF/UA output has no structure tree"
+
+
+def test_fonts_accept_bytes_and_base64_identically():
+    raw = FONT.read_bytes()
+    b64 = base64.b64encode(raw).decode("ascii")
+    opts = dict(pdfa="2b", lang="en")
+    from_bytes = render_html(
+        HTML, fonts=[{"family": "Liberation Sans", "data": raw, "weight": 400}], **opts
+    )
+    from_b64 = render_html(
+        HTML, fonts=[{"family": "Liberation Sans", "data": b64, "weight": 400}], **opts
+    )
+    # Same font, expressed two ways => identical embedded program => same bytes.
+    assert from_bytes == from_b64
+
+
+def test_default_is_not_pdfa():
+    # Sanity: the plain render must NOT carry PDF/A conformance.
+    assert b"pdfaid" not in render_html(HTML)


### PR DESCRIPTION
The python-sdk suite covers the client, the component DSL, and `render_pdf`, but `render_html` (added with the HTML path in #107) was only exercised by the byte-parity gate — its Python-facing options had no tests.

Adds 9 self-contained tests (no Node, no network): each option reaches the engine and shapes output, and failures raise `FormeRenderError` — page size (+ unknown-size error), css injection, PDF/A-2b with an embedded font (pdfaid marker) + the no-font error, PDF/UA structure tree, and fonts-as-bytes == fonts-as-base64.

Full suite: 96 passed, 2 skipped (parity tests skip without a Node reference).