### PR TITLE
pdf-testkit 0.5.0 + enable the new content-change check on the baselines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@pdf-testkit/cli": "^0.4.1",
+        "@pdf-testkit/cli": "^0.5.0",
         "miniflare": "4.20260730.0",
         "puppeteer-core": "25.10.0",
         "sharp": "0.34.4"
@@ -2657,15 +2657,15 @@
       "peer": true
     },
     "node_modules/@pdf-testkit/cli": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.4.1.tgz",
-      "integrity": "sha512-toFmup736719jg0sTK8JC665GT/HG8oeq017buodNPt77qrbGb4Azwg8ThBACSQI2HOSfNXHuvnsHzznbWmwZg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/cli/-/cli-0.5.0.tgz",
+      "integrity": "sha512-PPhqAy9E66CVzBgyn0CCwVD4jrfr/2vaYktkz4j0RYqIKPT+/5hT3Xwjx2O8D1mXdhCqDJhDxiFE2kA2n+T9rQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.1",
-        "@pdf-testkit/matcher-core": "^0.4.1",
-        "@pdf-testkit/protocol": "^0.4.1",
+        "@pdf-testkit/core": "^0.5.0",
+        "@pdf-testkit/matcher-core": "^0.5.0",
+        "@pdf-testkit/protocol": "^0.5.0",
         "commander": "^12.1.0",
         "pdfjs-dist": "^4.10.38"
       },
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@pdf-testkit/core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.4.1.tgz",
-      "integrity": "sha512-r9umP9h1d6FMduFIxL0Z1Vu1d1OQjl5Bmyws84/Lnti1o8inLgGvzeco8doG3c4Ww2z46C5kYBSdMYg9BR7TzA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-YgH2DHHsgviyMFzF8lAFp94y4IFMYWOhjiJNLCYz15+P/ILCK4xJu7fiFa05IexYMJPD/XSaK8jVrGXGUM8NAw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2693,19 +2693,19 @@
       }
     },
     "node_modules/@pdf-testkit/matcher-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.4.1.tgz",
-      "integrity": "sha512-y+ez0aBOIlGskkljX0KHvYbloemPK3lW5oISGQy6nfKzotD0zzEC3YNoSjUvzWO7cAgcsjVMYlZIaX0NYg64iw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/matcher-core/-/matcher-core-0.5.0.tgz",
+      "integrity": "sha512-eFb2/4RLQOzgSmxxix80G8jFK1PmWL7ebAwyMg7FS8vSfFKldjnG+97qHiq9qcvOAOJFFwgAHuWpkJbvSoWUDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.1"
+        "@pdf-testkit/core": "^0.5.0"
       }
     },
     "node_modules/@pdf-testkit/protocol": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.4.1.tgz",
-      "integrity": "sha512-6XH7mzLdBo72nw1YZCxqGNF5Tk2r4oFfsSvDd55cAEcty6NEcm9DDu0bV8d42WXOxRPBZgCF7gU/Wj91FVQ2zg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/protocol/-/protocol-0.5.0.tgz",
+      "integrity": "sha512-hjEt8oToTX67yB/UhFQU82Iv98E+6lsm+qsuLFkLQoNc4Ozexbz7F0wILMZa46J9+XqDhJ0eUmWJ6VVFR/i9ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2713,14 +2713,14 @@
       }
     },
     "node_modules/@pdf-testkit/vitest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.4.1.tgz",
-      "integrity": "sha512-QwI6bCGz1RjF3xfVBiC3kUJmWAxpd14nYa87QaNKaX5gutCZHaflohoSoveh8OXsHakw08Td0fEi+XmGm3qIsg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pdf-testkit/vitest/-/vitest-0.5.0.tgz",
+      "integrity": "sha512-aFqD2dlomwm5YkVs+U9LjNJxEaSkrj7fUBXSMXGBnAwJ7U/YKiuXQRXvKxm21IxL5U323CpUMjpmdGayMf0NZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pdf-testkit/core": "^0.4.1",
-        "@pdf-testkit/matcher-core": "^0.4.1"
+        "@pdf-testkit/core": "^0.5.0",
+        "@pdf-testkit/matcher-core": "^0.5.0"
       },
       "peerDependencies": {
         "vitest": ">=1"
@@ -8973,7 +8973,7 @@
         "@formepdf/fonts-standard": "0.22.0",
         "@formepdf/html": "^0.22.0",
         "@formepdf/templates": "0.22.0",
-        "@pdf-testkit/vitest": "^0.4.1",
+        "@pdf-testkit/vitest": "^0.5.0",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@pdf-testkit/cli": "^0.4.1",
+    "@pdf-testkit/cli": "^0.5.0",
     "miniflare": "4.20260730.0",
     "puppeteer-core": "25.10.0",
     "sharp": "0.34.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,7 +73,7 @@
     "@cloudflare/vitest-pool-workers": "^0.22.0",
     "@formepdf/templates": "0.22.0",
     "@formepdf/html": "^0.22.0",
-    "@pdf-testkit/vitest": "^0.4.1",
+    "@pdf-testkit/vitest": "^0.5.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "react": "^19.0.0",

--- a/packages/core/tests/html-fixtures.regression.test.ts
+++ b/packages/core/tests/html-fixtures.regression.test.ts
@@ -41,7 +41,7 @@ describe('html fixture regressions (the byte-wall corpus, structurally)', () => 
         'utf8',
       );
       const { layout } = renderHtmlWithLayout(html);
-      await expect(layout).toMatchPDFSnapshot({ snapshotName: `html-fixture-${name}` });
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: `html-fixture-${name}`, contentChanges: true });
     },
   );
 });

--- a/packages/core/tests/pdf-testkit.dogfood.test.ts
+++ b/packages/core/tests/pdf-testkit.dogfood.test.ts
@@ -45,6 +45,15 @@ describe('pdf-testkit dogfood — FormePDF verifies its own layout', () => {
     const { layout } = await renderDocumentWithLayout(invoice());
     // Pass the LayoutInfo directly — the authoritative FormePDF fast path
     // (no PDF parsing, every node at confidence 1.0).
-    await expect(layout).toMatchPDFSnapshot({ snapshotName: 'invoice' });
+    //
+    // `contentChanges` (pdf-testkit 0.5.0, opt-in) also reports a text edit
+    // at a stable slot — structural diffing is silent on those by design.
+    // These baselines render FIXED fixtures, so any text change is the
+    // renderer changing what it emits (an encoding or glyph-substitution
+    // regression, the "≤ printed as ?" class), never legitimate data drift.
+    // Verified to bite: a $98.00 -> $98.99 cell edit in the invoice fixture
+    // raises element-content-changed (warn), and the matcher fails on any
+    // severity above info.
+    await expect(layout).toMatchPDFSnapshot({ snapshotName: 'invoice', contentChanges: true });
   });
 });

--- a/packages/core/tests/templates-demo.regression.test.ts
+++ b/packages/core/tests/templates-demo.regression.test.ts
@@ -82,7 +82,7 @@ describe('demo template regressions (/templates)', () => {
 
       // Pass LayoutInfo directly — the authoritative FormePDF fast path
       // (no PDF parsing, every node at confidence 1.0).
-      await expect(layout).toMatchPDFSnapshot({ snapshotName: `demo-${name}` });
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: `demo-${name}`, contentChanges: true });
     },
   );
 
@@ -94,7 +94,7 @@ describe('demo template regressions (/templates)', () => {
       // above) clean on machines without it.
       const { default: GridDashboard } = await import('../../../templates/grid-dashboard');
       const { layout } = await renderDocumentWithLayout(GridDashboard(gridDashboardData));
-      await expect(layout).toMatchPDFSnapshot({ snapshotName: 'demo-grid-dashboard' });
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: 'demo-grid-dashboard', contentChanges: true });
     },
   );
 });

--- a/packages/core/tests/templates.regression.test.ts
+++ b/packages/core/tests/templates.regression.test.ts
@@ -54,7 +54,7 @@ describe('shipped template regressions (@formepdf/templates)', () => {
 
       // Pass LayoutInfo directly — the authoritative FormePDF fast path
       // (no PDF parsing, every node at confidence 1.0).
-      await expect(layout).toMatchPDFSnapshot({ snapshotName: `template-${name}` });
+      await expect(layout).toMatchPDFSnapshot({ snapshotName: `template-${name}`, contentChanges: true });
     },
   );
 


### PR DESCRIPTION
Bumps `@pdf-testkit/cli` (root) and `@pdf-testkit/vitest` (packages/core) `^0.4.1` → `^0.5.0`. Caret ranges on 0.x don't admit a new minor, so both pins needed the explicit move; the tree resolves to 0.5.0 throughout and the CLI `upload` flags CI passes (`--conformance`, `--require-service`) are unchanged.

## The new check, enabled

0.5.0's headline is **F1**: an opt-in `element-content-changed` event for a text edit at a stable slot — the case structural diffing is silent on by design (the pair keeps its slot, so no geometry event fires).

Forme's baselines render **fixed** fixtures, so a text change there is always the renderer changing what it emits — an encoding or glyph-substitution regression, the "≤ printed as ?" class that shipped once already — never legitimate data drift. All five baseline call sites now pass `contentChanges: true`.

**Verified to bite, not merely enabled**: rendering `html/tests/fixtures/invoice.html` with one cell edited `$98.00` → `$98.99` produces

```
default      → (none)
contentChanges → element-content-changed/warn: cell content changed "$98.00" → "$98.99" on page 1
```

and the matcher fails on any severity above `info`. Suites stay green as-is: 89 core tests + 21 template tests, so today's baselines are content-stable.

## Method note

`diffSnapshots` short-circuits on equal `contentHash`, so hand-editing a committed baseline's nodes proves nothing — the stale hash makes the diff report "identical". Mutate the input and re-render instead. (Cost me three misleading probes before I isolated it.)