### PR TITLE
Docs: drop the playground link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,12 +10,6 @@
   "colors": {
     "primary": "#111827"
   },
-  "topbarLinks": [
-    {
-      "name": "Playground",
-      "url": "https://playground.formepdf.com/"
-    }
-  ],
   "topbarCtaButton": {
     "name": "Get Started",
     "url": "https://github.com/formepdf/forme"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,8 +7,6 @@ Forme is a PDF generation library for React and TypeScript. You write JSX compon
 
 > **Using Svelte or Vue?** The [Svelte](/svelte) and [Vue](/vue) adapters ship the same components with the same props — see their guides.
 
-Want to try it first? **[Open the playground](https://playground.formepdf.com/)** — no install needed.
-
 ## 1. Install
 
 ```bash


### PR DESCRIPTION
Removes the Playground entry from the docs topbar (`docs.json`) and the "Open the playground" line from the quickstart. No other docs page references it.